### PR TITLE
fix: Fix routing for GitHub Pages subpath deployment

### DIFF
--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
Fixes #7

This PR resolves the GitHub Pages routing issue where the "Go to bookmarks" button was navigating to the root domain instead of the correct subpath.

## Changes:
- Added `getBasePath()` method to detect Vite base URL
- Added `getRouteFromPath()` method to strip base path from URLs
- Updated `updateUrl()` method to add base path back when generating URLs
- Created `vite-env.d.ts` for TypeScript environment types
- Maintains compatibility with local development and other deployments

The solution automatically detects the correct base path and handles routing appropriately for both local development and GitHub Pages deployment.

Generated with [Claude Code](https://claude.ai/code)