### PR TITLE
fix: resolve icon loading issue on GitHub Pages

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,11 @@ import { registerIcons } from './icons';
 import './components/app-root';
 
 // Set Shoelace base path for bundled assets
-setBasePath('/shoelace/');
+// Determine base path based on environment (match Vite configuration)
+const isGitHubPages = window.location.hostname === 'garyp.github.io' || 
+                      window.location.pathname.startsWith('/pocket-ding/');
+const basePath = isGitHubPages ? '/pocket-ding/shoelace/' : '/shoelace/';
+setBasePath(basePath);
 
 // Register icons for tree shaking
 registerIcons();


### PR DESCRIPTION
This PR fixes the icon loading issue on GitHub Pages by dynamically setting the correct Shoelace base path.

## Changes
- Updated `src/main.ts` to detect GitHub Pages deployment and adjust Shoelace base path
- Maintained backwards compatibility with local development

## Testing
The fix should resolve the icon visibility issue on https://garyp.github.io/pocket-ding/

Fixes #15

Generated with [Claude Code](https://claude.ai/code)