### PR TITLE
Fix top bar icon visibility with explicit color styling

### DIFF
--- a/src/components/app-root.ts
+++ b/src/components/app-root.ts
@@ -63,6 +63,11 @@ export class AppRoot extends LitElement {
       --md-text-button-label-text-color: var(--md-sys-color-on-primary);
     }
 
+    .header-actions md-text-button md-icon,
+    .app-header md-text-button md-icon {
+      color: var(--md-sys-color-on-primary);
+    }
+
     .app-content {
       flex: 1;
       overflow-y: auto;


### PR DESCRIPTION
Fixes #27 - Icons don't work after the migration to Material components

## Summary

- Add explicit color styling for `md-icon` elements in top bar buttons
- Use Material Design color tokens (`--md-sys-color-on-primary`) for proper theme support
- Resolves remaining icon visibility issue in header after Material Symbols migration

## Technical Details

The previous fix successfully migrated from Material Icons to Material Symbols, but the top bar icons specifically needed explicit color styling. The `--md-text-button-label-text-color` CSS custom property only affects button text labels, not the `md-icon` elements slotted within the buttons.

## Test Plan

- [x] All 46 tests pass
- [x] Build successful
- [x] TypeScript compilation clean
- [ ] Visual verification of top bar icons in browser

Generated with [Claude Code](https://claude.ai/code)