### PR TITLE
Add export/import functionality for non-Linkding state

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,87 @@ For testing and demonstration purposes, you can use the app without setting up a
 - New bookmarks and updates from Linkding are downloaded automatically
 - Article content is fetched and cached for offline reading
 
+## Data Export/Import
+
+Pocket Ding supports exporting and importing your local reading progress and app settings. This allows you to backup your data, migrate between devices, or reset your local data without losing reading progress.
+
+### What Gets Exported
+
+The export includes your **local-only data** that is not stored on the Linkding server:
+
+- **Reading Progress**: Reading percentage, scroll position, last read timestamps, reading mode preferences, and dark mode overrides for each bookmark
+- **App Settings**: Sync interval, auto-sync preferences, default reading mode, and theme preferences (excludes server credentials)
+- **Sync Metadata**: Last sync timestamp for maintaining sync consistency
+
+**Note**: The export does not include your bookmarks (which are stored on your Linkding server) or cached website content (which can be re-downloaded).
+
+### Using Export/Import
+
+1. Go to **Settings** in the app
+2. Scroll to the **Data Management** section
+3. Click **Export Data** to download a JSON file with your local data
+4. Click **Import Data** to upload and import a previously exported JSON file
+
+### Export File Format
+
+The export file is a JSON document with the following structure:
+
+```json
+{
+  "version": "1.0",
+  "export_timestamp": "2025-01-15T10:30:00.000Z",
+  "reading_progress": [
+    {
+      "bookmark_id": 123,
+      "progress": 0.75,
+      "last_read_at": "2025-01-15T09:45:00.000Z",
+      "reading_mode": "readability",
+      "scroll_position": 1500,
+      "dark_mode_override": "dark"
+    }
+  ],
+  "app_settings": {
+    "sync_interval": 60,
+    "auto_sync": true,
+    "reading_mode": "readability",
+    "theme_mode": "system"
+  },
+  "sync_metadata": {
+    "last_sync_timestamp": "2025-01-15T10:00:00.000Z"
+  }
+}
+```
+
+#### Field Descriptions
+
+- **version**: Schema version for compatibility checking
+- **export_timestamp**: When the export was created (ISO 8601 format)
+- **reading_progress**: Array of reading progress records
+  - **bookmark_id**: ID of the bookmark from Linkding server
+  - **progress**: Reading progress as a decimal (0.0 to 1.0)
+  - **last_read_at**: Timestamp when reading progress was last updated
+  - **reading_mode**: "original" or "readability"
+  - **scroll_position**: Vertical scroll position in pixels
+  - **dark_mode_override**: "light", "dark", or null for per-bookmark theme override
+- **app_settings**: Application preferences (server credentials excluded)
+  - **sync_interval**: Sync frequency in minutes
+  - **auto_sync**: Boolean for automatic sync
+  - **reading_mode**: Default reading mode ("original" or "readability")
+  - **theme_mode**: Global theme preference ("light", "dark", or "system")
+- **sync_metadata**: Synchronization state
+  - **last_sync_timestamp**: Last successful sync with Linkding server
+
+### Import Behavior
+
+When importing data:
+
+- **Reading Progress**: Only imported if the import timestamp is newer than existing data for that bookmark
+- **Orphaned Progress**: Reading progress for non-existent bookmarks is skipped
+- **App Settings**: Merged with existing settings (server credentials are preserved)
+- **Sync Metadata**: Updated if present in import
+
+This ensures that importing old data won't overwrite newer reading progress and that your server configuration remains intact.
+
 ## Development
 
 ### Available Scripts

--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ The export includes your **local-only data** that is not stored on the Linkding 
 
 - **Reading Progress**: Reading percentage, scroll position, last read timestamps, reading mode preferences, and dark mode overrides for each bookmark
 - **App Settings**: Sync interval, auto-sync preferences, default reading mode, and theme preferences (excludes server credentials)
-- **Sync Metadata**: Last sync timestamp for maintaining sync consistency
 
 **Note**: The export does not include your bookmarks (which are stored on your Linkding server) or cached website content (which can be re-downloaded).
 
@@ -131,9 +130,6 @@ The export file is a JSON document with the following structure:
     "auto_sync": true,
     "reading_mode": "readability",
     "theme_mode": "system"
-  },
-  "sync_metadata": {
-    "last_sync_timestamp": "2025-01-15T10:00:00.000Z"
   }
 }
 ```
@@ -154,8 +150,6 @@ The export file is a JSON document with the following structure:
   - **auto_sync**: Boolean for automatic sync
   - **reading_mode**: Default reading mode ("original" or "readability")
   - **theme_mode**: Global theme preference ("light", "dark", or "system")
-- **sync_metadata**: Synchronization state
-  - **last_sync_timestamp**: Last successful sync with Linkding server
 
 ### Import Behavior
 
@@ -164,9 +158,8 @@ When importing data:
 - **Reading Progress**: Only imported if the import timestamp is newer than existing data for that bookmark
 - **Orphaned Progress**: Reading progress for non-existent bookmarks is skipped
 - **App Settings**: Merged with existing settings (server credentials are preserved)
-- **Sync Metadata**: Updated if present in import
 
-This ensures that importing old data won't overwrite newer reading progress and that your server configuration remains intact.
+This ensures that importing old data won't overwrite newer reading progress and that your server configuration remains intact. After importing, a full sync will be performed to ensure your data is up to date.
 
 ## Development
 

--- a/src/controllers/data-management-controller.ts
+++ b/src/controllers/data-management-controller.ts
@@ -1,5 +1,5 @@
 import { type ReactiveController, type ReactiveControllerHost } from 'lit';
-import { ExportService } from '../services/export-service';
+import { ExportService, type ExportResult } from '../services/export-service';
 import { ImportService, type ImportResult } from '../services/import-service';
 
 export interface DataManagementState {
@@ -53,11 +53,23 @@ export class DataManagementController implements ReactiveController {
     });
 
     try {
-      await ExportService.exportToFile();
-      this.updateState({
-        testStatus: 'success',
-        testMessage: 'Data exported successfully!'
-      });
+      const result: ExportResult = await ExportService.exportToFile();
+      
+      if (result.success) {
+        let message = 'Data exported successfully!';
+        if (result.warnings.length > 0) {
+          message += ' Warning: ' + result.warnings.join(' ');
+        }
+        this.updateState({
+          testStatus: 'success',
+          testMessage: message
+        });
+      } else {
+        this.updateState({
+          testStatus: 'error',
+          testMessage: `Export failed: ${result.warnings.join(' ')}`
+        });
+      }
     } catch (error) {
       console.error('Export failed:', error);
       this.updateState({

--- a/src/controllers/data-management-controller.ts
+++ b/src/controllers/data-management-controller.ts
@@ -1,0 +1,179 @@
+import { type ReactiveController, type ReactiveControllerHost } from 'lit';
+import { ExportService } from '../services/export-service';
+import { ImportService, type ImportResult } from '../services/import-service';
+
+export interface DataManagementState {
+  isExporting: boolean;
+  isImporting: boolean;
+  importResult: ImportResult | null;
+  importFileInput: HTMLInputElement | null;
+  testStatus: 'idle' | 'testing' | 'success' | 'error';
+  testMessage: string;
+}
+
+export class DataManagementController implements ReactiveController {
+  private host: ReactiveControllerHost;
+  
+  public state: DataManagementState = {
+    isExporting: false,
+    isImporting: false,
+    importResult: null,
+    importFileInput: null,
+    testStatus: 'idle',
+    testMessage: ''
+  };
+
+  constructor(host: ReactiveControllerHost) {
+    this.host = host;
+    host.addController(this);
+  }
+
+  hostConnected() {
+    // Controller lifecycle - called when host connects
+  }
+
+  hostDisconnected() {
+    // Clean up file input if it exists
+    if (this.state.importFileInput) {
+      this.state.importFileInput.remove();
+      this.state.importFileInput = null;
+    }
+  }
+
+  private updateState(updates: Partial<DataManagementState>) {
+    Object.assign(this.state, updates);
+    this.host.requestUpdate();
+  }
+
+  async exportData(): Promise<void> {
+    this.updateState({
+      isExporting: true,
+      testStatus: 'idle',
+      importResult: null
+    });
+
+    try {
+      await ExportService.exportToFile();
+      this.updateState({
+        testStatus: 'success',
+        testMessage: 'Data exported successfully!'
+      });
+    } catch (error) {
+      console.error('Export failed:', error);
+      this.updateState({
+        testStatus: 'error',
+        testMessage: `Export failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+      });
+    } finally {
+      this.updateState({ isExporting: false });
+    }
+  }
+
+  startImport(): void {
+    // Create a hidden file input if it doesn't exist
+    if (!this.state.importFileInput) {
+      const input = document.createElement('input');
+      input.type = 'file';
+      input.accept = '.json,application/json';
+      input.style.display = 'none';
+      input.addEventListener('change', this.handleFileSelected.bind(this));
+      
+      // Append to the host element's shadow root or document body
+      const hostElement = this.host as any;
+      if (hostElement.shadowRoot) {
+        hostElement.shadowRoot.appendChild(input);
+      } else {
+        document.body.appendChild(input);
+      }
+      
+      this.updateState({ importFileInput: input });
+    }
+    
+    this.state.importFileInput?.click();
+  }
+
+  private async handleFileSelected(event: Event): Promise<void> {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    
+    if (!file) return;
+
+    this.updateState({
+      isImporting: true,
+      testStatus: 'idle',
+      importResult: null
+    });
+
+    try {
+      // Validate file first
+      const validation = await ImportService.validateImportFile(file);
+      if (!validation.valid) {
+        this.updateState({
+          testStatus: 'error',
+          testMessage: validation.error || 'Invalid file'
+        });
+        return;
+      }
+
+      // Perform import
+      const result = await ImportService.importFromFile(file);
+      this.updateState({ importResult: result });
+
+      if (result.success) {
+        this.updateState({
+          testStatus: 'success',
+          testMessage: 'Data imported successfully!'
+        });
+        
+        // Trigger settings refresh if settings were imported
+        if (result.imported_settings) {
+          this.dispatchSettingsUpdated();
+        }
+      } else {
+        this.updateState({
+          testStatus: 'error',
+          testMessage: 'Import completed with errors'
+        });
+      }
+    } catch (error) {
+      console.error('Import failed:', error);
+      this.updateState({
+        testStatus: 'error',
+        testMessage: `Import failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        importResult: {
+          success: false,
+          imported_progress_count: 0,
+          skipped_progress_count: 0,
+          orphaned_progress_count: 0,
+          imported_settings: false,
+          imported_sync_metadata: false,
+          errors: [error instanceof Error ? error.message : 'Unknown error']
+        }
+      });
+    } finally {
+      this.updateState({ isImporting: false });
+      // Clear the input value so the same file can be selected again
+      if (input) {
+        input.value = '';
+      }
+    }
+  }
+
+  private dispatchSettingsUpdated(): void {
+    const hostElement = this.host as any;
+    if (hostElement.dispatchEvent) {
+      hostElement.dispatchEvent(new CustomEvent('settings-updated', {
+        bubbles: true,
+        composed: true
+      }));
+    }
+  }
+
+  clearMessages(): void {
+    this.updateState({
+      testStatus: 'idle',
+      testMessage: '',
+      importResult: null
+    });
+  }
+}

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -83,6 +83,10 @@ export class DatabaseService {
     return results.sort((a, b) => new Date(b.last_read_at).getTime() - new Date(a.last_read_at).getTime())[0];
   }
 
+  static async getAllReadProgress(): Promise<ReadProgress[]> {
+    return await db.readProgress.toArray();
+  }
+
   static async saveSettings(settings: AppSettings): Promise<void> {
     await db.settings.clear();
     await db.settings.add(settings);

--- a/src/services/export-service.ts
+++ b/src/services/export-service.ts
@@ -1,0 +1,159 @@
+import { DatabaseService } from './database';
+import type { ReadProgress } from '../types';
+
+export interface ExportData {
+  version: string;
+  export_timestamp: string;
+  reading_progress: ReadProgress[];
+  app_settings: {
+    sync_interval: number;
+    auto_sync: boolean;
+    reading_mode: 'original' | 'readability';
+    theme_mode?: 'light' | 'dark' | 'system';
+  };
+  sync_metadata: {
+    last_sync_timestamp: string | null;
+  };
+}
+
+export class ExportService {
+  private static readonly EXPORT_VERSION = '1.0';
+
+  static async exportData(): Promise<ExportData> {
+    try {
+      // Get all reading progress records
+      const readingProgress = await this.getAllReadingProgress();
+      
+      // Get app settings (excluding sensitive server data)
+      const settings = await DatabaseService.getSettings();
+      const appSettings: {
+        sync_interval: number;
+        auto_sync: boolean;
+        reading_mode: 'original' | 'readability';
+        theme_mode?: 'light' | 'dark' | 'system';
+      } = {
+        sync_interval: settings?.sync_interval || 60,
+        auto_sync: settings?.auto_sync ?? true,
+        reading_mode: settings?.reading_mode || 'readability' as const
+      };
+      
+      if (settings?.theme_mode) {
+        appSettings.theme_mode = settings.theme_mode;
+      }
+
+      // Get sync metadata
+      const lastSyncTimestamp = await DatabaseService.getLastSyncTimestamp();
+
+      const exportData: ExportData = {
+        version: this.EXPORT_VERSION,
+        export_timestamp: new Date().toISOString(),
+        reading_progress: readingProgress,
+        app_settings: appSettings,
+        sync_metadata: {
+          last_sync_timestamp: lastSyncTimestamp
+        }
+      };
+
+      return exportData;
+    } catch (error) {
+      throw new Error(`Failed to export data: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  }
+
+  static async exportToFile(): Promise<void> {
+    try {
+      const data = await this.exportData();
+      const jsonString = JSON.stringify(data, null, 2);
+      const blob = new Blob([jsonString], { type: 'application/json' });
+      
+      // Generate filename with timestamp
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+      const filename = `pocket-ding-export-${timestamp}.json`;
+      
+      // Use modern File API to download
+      if ('showSaveFilePicker' in window) {
+        // Use File System Access API if available
+        const fileHandle = await (window as any).showSaveFilePicker({
+          suggestedName: filename,
+          types: [{
+            description: 'JSON files',
+            accept: { 'application/json': ['.json'] }
+          }]
+        });
+        
+        const writable = await fileHandle.createWritable();
+        await writable.write(blob);
+        await writable.close();
+      } else {
+        // Fallback to download link
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      }
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        // User cancelled the save dialog
+        return;
+      }
+      throw new Error(`Failed to export to file: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  }
+
+  private static async getAllReadingProgress(): Promise<ReadProgress[]> {
+    // Since there's no direct method to get all reading progress,
+    // we need to query the database directly
+    const { db } = await import('./database');
+    return await db.readProgress.toArray();
+  }
+
+  static validateExportData(data: any): data is ExportData {
+    if (!data || typeof data !== 'object') {
+      return false;
+    }
+
+    // Check required fields
+    if (typeof data.version !== 'string' ||
+        typeof data.export_timestamp !== 'string' ||
+        !Array.isArray(data.reading_progress) ||
+        typeof data.app_settings !== 'object' ||
+        typeof data.sync_metadata !== 'object') {
+      return false;
+    }
+
+    // Validate reading progress entries
+    for (const progress of data.reading_progress) {
+      if (!this.isValidReadProgress(progress)) {
+        return false;
+      }
+    }
+
+    // Validate app settings
+    const settings = data.app_settings;
+    if (typeof settings.sync_interval !== 'number' ||
+        typeof settings.auto_sync !== 'boolean' ||
+        !['original', 'readability'].includes(settings.reading_mode)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  private static isValidReadProgress(progress: any): progress is ReadProgress {
+    return (
+      typeof progress === 'object' &&
+      typeof progress.bookmark_id === 'number' &&
+      typeof progress.progress === 'number' &&
+      typeof progress.last_read_at === 'string' &&
+      ['original', 'readability'].includes(progress.reading_mode) &&
+      typeof progress.scroll_position === 'number' &&
+      (progress.dark_mode_override === null || 
+       progress.dark_mode_override === undefined ||
+       ['light', 'dark'].includes(progress.dark_mode_override))
+    );
+  }
+}

--- a/src/services/import-service.ts
+++ b/src/services/import-service.ts
@@ -1,0 +1,219 @@
+import { DatabaseService } from './database';
+import { ExportService, type ExportData } from './export-service';
+import type { ReadProgress, AppSettings } from '../types';
+
+export interface ImportResult {
+  success: boolean;
+  imported_progress_count: number;
+  skipped_progress_count: number;
+  imported_settings: boolean;
+  imported_sync_metadata: boolean;
+  errors: string[];
+}
+
+export class ImportService {
+  static async importFromFile(file: File): Promise<ImportResult> {
+    try {
+      const jsonText = await this.readFileAsText(file);
+      const data = JSON.parse(jsonText);
+      return await this.importData(data);
+    } catch (error) {
+      return {
+        success: false,
+        imported_progress_count: 0,
+        skipped_progress_count: 0,
+        imported_settings: false,
+        imported_sync_metadata: false,
+        errors: [`Failed to read file: ${error instanceof Error ? error.message : 'Unknown error'}`]
+      };
+    }
+  }
+
+  static async importData(data: any): Promise<ImportResult> {
+    const result: ImportResult = {
+      success: false,
+      imported_progress_count: 0,
+      skipped_progress_count: 0,
+      imported_settings: false,
+      imported_sync_metadata: false,
+      errors: []
+    };
+
+    try {
+      // Validate export data format
+      if (!ExportService.validateExportData(data)) {
+        result.errors.push('Invalid export data format');
+        return result;
+      }
+
+      const exportData = data as ExportData;
+
+      // Import reading progress with timestamp precedence
+      const progressResult = await this.importReadingProgress(exportData.reading_progress);
+      result.imported_progress_count = progressResult.imported;
+      result.skipped_progress_count = progressResult.skipped;
+      result.errors.push(...progressResult.errors);
+
+      // Import app settings (excluding server configuration)
+      try {
+        await this.importAppSettings(exportData.app_settings);
+        result.imported_settings = true;
+      } catch (error) {
+        result.errors.push(`Failed to import settings: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      }
+
+      // Import sync metadata
+      try {
+        if (exportData.sync_metadata.last_sync_timestamp) {
+          await DatabaseService.setLastSyncTimestamp(exportData.sync_metadata.last_sync_timestamp);
+          result.imported_sync_metadata = true;
+        }
+      } catch (error) {
+        result.errors.push(`Failed to import sync metadata: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      }
+
+      result.success = result.errors.length === 0;
+      return result;
+    } catch (error) {
+      result.errors.push(`Import failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      return result;
+    }
+  }
+
+  private static async importReadingProgress(progressList: ReadProgress[]): Promise<{
+    imported: number;
+    skipped: number;
+    errors: string[];
+  }> {
+    let imported = 0;
+    let skipped = 0;
+    const errors: string[] = [];
+
+    for (const importProgress of progressList) {
+      try {
+        // Check if bookmark exists in the database
+        const bookmark = await DatabaseService.getBookmark(importProgress.bookmark_id);
+        if (!bookmark) {
+          // Skip orphaned progress (bookmark doesn't exist)
+          skipped++;
+          continue;
+        }
+
+        // Get existing reading progress for this bookmark
+        const existingProgress = await DatabaseService.getReadProgress(importProgress.bookmark_id);
+
+        if (existingProgress) {
+          // Compare timestamps to decide whether to import
+          const existingTimestamp = new Date(existingProgress.last_read_at).getTime();
+          const importTimestamp = new Date(importProgress.last_read_at).getTime();
+
+          if (importTimestamp <= existingTimestamp) {
+            // Import data is older or same age, skip
+            skipped++;
+            continue;
+          }
+        }
+
+        // Import the reading progress (either no existing data or import is newer)
+        await DatabaseService.saveReadProgress(importProgress);
+        imported++;
+      } catch (error) {
+        errors.push(`Failed to import progress for bookmark ${importProgress.bookmark_id}: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        skipped++;
+      }
+    }
+
+    return { imported, skipped, errors };
+  }
+
+  private static async importAppSettings(importSettings: ExportData['app_settings']): Promise<void> {
+    // Get current settings to preserve server configuration
+    const currentSettings = await DatabaseService.getSettings();
+
+    if (!currentSettings) {
+      throw new Error('No existing settings found. Please configure Linkding server settings first.');
+    }
+
+    // Merge import settings with existing server configuration
+    const mergedSettings: AppSettings = {
+      ...currentSettings, // Preserve linkding_url and linkding_token
+      sync_interval: importSettings.sync_interval,
+      auto_sync: importSettings.auto_sync,
+      reading_mode: importSettings.reading_mode
+    };
+
+    // Only set theme_mode if it's provided in the import
+    if (importSettings.theme_mode) {
+      mergedSettings.theme_mode = importSettings.theme_mode;
+    }
+
+    await DatabaseService.saveSettings(mergedSettings);
+  }
+
+  private static async readFileAsText(file: File): Promise<string> {
+    // Check if the browser supports streaming
+    if (file.stream && typeof file.stream === 'function') {
+      // Use streaming for large files if supported
+      const stream = file.stream();
+      const reader = stream.getReader();
+      const decoder = new TextDecoder();
+      let result = '';
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          result += decoder.decode(value, { stream: true });
+        }
+        result += decoder.decode(); // Final decode without stream flag
+        return result;
+      } finally {
+        reader.releaseLock();
+      }
+    } else {
+      // Fallback to reading entire file into memory
+      return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          if (e.target?.result && typeof e.target.result === 'string') {
+            resolve(e.target.result);
+          } else {
+            reject(new Error('Failed to read file as text'));
+          }
+        };
+        reader.onerror = () => reject(new Error('File reading error'));
+        reader.readAsText(file);
+      });
+    }
+  }
+
+  static async validateImportFile(file: File): Promise<{ valid: boolean; error?: string }> {
+    try {
+      // Check file size (reasonable limit for JSON)
+      const maxSize = 100 * 1024 * 1024; // 100MB
+      if (file.size > maxSize) {
+        return { valid: false, error: 'File too large (max 100MB)' };
+      }
+
+      // Check file type
+      if (file.type !== 'application/json' && !file.name.toLowerCase().endsWith('.json')) {
+        return { valid: false, error: 'File must be a JSON file' };
+      }
+
+      // Try to parse as JSON and validate structure
+      const text = await this.readFileAsText(file);
+      const data = JSON.parse(text);
+      
+      if (!ExportService.validateExportData(data)) {
+        return { valid: false, error: 'Invalid export file format' };
+      }
+
+      return { valid: true };
+    } catch (error) {
+      return { 
+        valid: false, 
+        error: `Invalid file: ${error instanceof Error ? error.message : 'Unknown error'}` 
+      };
+    }
+  }
+}

--- a/src/test/unit/export-service.test.ts
+++ b/src/test/unit/export-service.test.ts
@@ -190,8 +190,10 @@ describe('ExportService', () => {
       vi.mocked(DatabaseService.getAllReadProgress).mockResolvedValue([]);
       vi.mocked(DatabaseService.getSettings).mockResolvedValue(undefined);
 
-      // Should not throw
-      await expect(ExportService.exportToFile()).resolves.toBeUndefined();
+      // Should not throw and return success
+      const result = await ExportService.exportToFile();
+      expect(result.success).toBe(true);
+      expect(result.warnings).toEqual([]);
     });
 
     it('should warn when export file exceeds 100MB', async () => {
@@ -213,19 +215,15 @@ describe('ExportService', () => {
       });
       global.Blob = mockBlob as any;
 
-      // Mock console.warn to capture the warning
-      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const result = await ExportService.exportToFile();
 
-      await ExportService.exportToFile();
+      // Verify warning was returned in result
+      expect(result.success).toBe(true);
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).toMatch(/Export file size is \d+\.\d+MB, which exceeds the recommended 100MB limit/);
 
-      // Verify warning was logged
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringMatching(/Export file size is \d+\.\d+MB, which exceeds the recommended 100MB limit/)
-      );
-
-      // Restore original Blob and console.warn
+      // Restore original Blob
       global.Blob = originalBlob;
-      consoleWarnSpy.mockRestore();
     });
   });
 

--- a/src/test/unit/export-service.test.ts
+++ b/src/test/unit/export-service.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { ExportService, type ExportData } from '../../services/export-service';
+import { DatabaseService } from '../../services/database';
+
+// Mock the database module
+vi.mock('../../services/database', () => ({
+  DatabaseService: {
+    getSettings: vi.fn(),
+    getLastSyncTimestamp: vi.fn()
+  },
+  db: {
+    readProgress: {
+      toArray: vi.fn()
+    }
+  }
+}));
+
+// Mock file system access APIs
+const mockShowSaveFilePicker = vi.fn();
+const mockCreateWritable = vi.fn();
+const mockWrite = vi.fn();
+const mockClose = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  
+  // Mock File System Access API
+  mockCreateWritable.mockReturnValue({
+    write: mockWrite,
+    close: mockClose
+  });
+  mockShowSaveFilePicker.mockReturnValue({
+    createWritable: mockCreateWritable
+  });
+  
+  // Mock URL.createObjectURL
+  global.URL.createObjectURL = vi.fn(() => 'blob:mock-url');
+  global.URL.revokeObjectURL = vi.fn();
+  
+  // Mock document methods
+  global.document.createElement = vi.fn().mockReturnValue({
+    href: '',
+    download: '',
+    click: vi.fn(),
+    remove: vi.fn()
+  } as any);
+  
+  // Mock document.body methods
+  const mockAppendChild = vi.fn();
+  const mockRemoveChild = vi.fn();
+  Object.defineProperty(global.document, 'body', {
+    value: {
+      appendChild: mockAppendChild,
+      removeChild: mockRemoveChild
+    },
+    writable: true
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ExportService', () => {
+  describe('exportData', () => {
+    it('should export all non-Linkding state data', async () => {
+      // Mock database responses
+      const mockReadProgress = [
+        {
+          bookmark_id: 1,
+          progress: 0.5,
+          last_read_at: '2023-01-01T12:00:00Z',
+          reading_mode: 'readability' as const,
+          scroll_position: 100,
+          dark_mode_override: 'dark' as const
+        },
+        {
+          bookmark_id: 2,
+          progress: 0.8,
+          last_read_at: '2023-01-02T12:00:00Z',
+          reading_mode: 'original' as const,
+          scroll_position: 200,
+          dark_mode_override: null
+        }
+      ];
+
+      const mockSettings = {
+        linkding_url: 'https://example.com',
+        linkding_token: 'secret-token',
+        sync_interval: 30,
+        auto_sync: false,
+        reading_mode: 'original' as const,
+        theme_mode: 'dark' as const
+      };
+
+      const mockSyncTimestamp = '2023-01-01T10:00:00Z';
+
+      // Mock database module import
+      const mockDb = await import('../../services/database');
+      vi.mocked(mockDb.db.readProgress.toArray).mockResolvedValue(mockReadProgress);
+      vi.mocked(DatabaseService.getSettings).mockResolvedValue(mockSettings);
+      vi.mocked(DatabaseService.getLastSyncTimestamp).mockResolvedValue(mockSyncTimestamp);
+
+      const result = await ExportService.exportData();
+
+      // Verify structure
+      expect(result).toMatchObject({
+        version: '1.0',
+        export_timestamp: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
+        reading_progress: mockReadProgress,
+        app_settings: {
+          sync_interval: 30,
+          auto_sync: false,
+          reading_mode: 'original',
+          theme_mode: 'dark'
+        },
+        sync_metadata: {
+          last_sync_timestamp: mockSyncTimestamp
+        }
+      });
+
+      // Verify sensitive data is excluded
+      expect((result.app_settings as any).linkding_url).toBeUndefined();
+      expect((result.app_settings as any).linkding_token).toBeUndefined();
+    });
+
+    it('should handle missing settings gracefully', async () => {
+      const mockDb = await import('../../services/database');
+      vi.mocked(mockDb.db.readProgress.toArray).mockResolvedValue([]);
+      vi.mocked(DatabaseService.getSettings).mockResolvedValue(undefined);
+      vi.mocked(DatabaseService.getLastSyncTimestamp).mockResolvedValue(null);
+
+      const result = await ExportService.exportData();
+
+      expect(result.app_settings).toEqual({
+        sync_interval: 60,
+        auto_sync: true,
+        reading_mode: 'readability',
+        theme_mode: undefined
+      });
+      expect(result.sync_metadata.last_sync_timestamp).toBeNull();
+    });
+
+    it('should throw error on database failure', async () => {
+      const mockDb = await import('../../services/database');
+      vi.mocked(mockDb.db.readProgress.toArray).mockRejectedValue(new Error('Database error'));
+
+      await expect(ExportService.exportData()).rejects.toThrow('Failed to export data: Database error');
+    });
+  });
+
+  describe('exportToFile', () => {
+    it('should use File System Access API when available', async () => {
+      // Mock window.showSaveFilePicker
+      (global as any).window = { showSaveFilePicker: mockShowSaveFilePicker };
+
+      const mockDb = await import('../../services/database');
+      vi.mocked(mockDb.db.readProgress.toArray).mockResolvedValue([]);
+      vi.mocked(DatabaseService.getSettings).mockResolvedValue(undefined);
+      vi.mocked(DatabaseService.getLastSyncTimestamp).mockResolvedValue(null);
+
+      await ExportService.exportToFile();
+
+      expect(mockShowSaveFilePicker).toHaveBeenCalledWith({
+        suggestedName: expect.stringMatching(/^pocket-ding-export-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.json$/),
+        types: [{
+          description: 'JSON files',
+          accept: { 'application/json': ['.json'] }
+        }]
+      });
+      expect(mockWrite).toHaveBeenCalled();
+      expect(mockClose).toHaveBeenCalled();
+    });
+
+    it('should fallback to download link when File System Access API not available', async () => {
+      // No showSaveFilePicker available
+      (global as any).window = {};
+
+      const mockDb = await import('../../services/database');
+      vi.mocked(mockDb.db.readProgress.toArray).mockResolvedValue([]);
+      vi.mocked(DatabaseService.getSettings).mockResolvedValue(undefined);
+      vi.mocked(DatabaseService.getLastSyncTimestamp).mockResolvedValue(null);
+
+      const mockAnchor = {
+        href: '',
+        download: '',
+        click: vi.fn(),
+        remove: vi.fn()
+      };
+      vi.mocked(document.createElement).mockReturnValue(mockAnchor as any);
+
+      await ExportService.exportToFile();
+
+      expect(document.createElement).toHaveBeenCalledWith('a');
+      expect(mockAnchor.click).toHaveBeenCalled();
+      expect(global.URL.createObjectURL).toHaveBeenCalled();
+      expect(global.URL.revokeObjectURL).toHaveBeenCalled();
+    });
+
+    it('should handle user cancellation gracefully', async () => {
+      (global as any).window = { showSaveFilePicker: mockShowSaveFilePicker };
+      
+      // Create an error with the name property set to 'AbortError'
+      const abortError = new Error('User cancelled');
+      abortError.name = 'AbortError';
+      mockShowSaveFilePicker.mockRejectedValue(abortError);
+
+      const mockDb = await import('../../services/database');
+      vi.mocked(mockDb.db.readProgress.toArray).mockResolvedValue([]);
+      vi.mocked(DatabaseService.getSettings).mockResolvedValue(undefined);
+      vi.mocked(DatabaseService.getLastSyncTimestamp).mockResolvedValue(null);
+
+      // Should not throw
+      await expect(ExportService.exportToFile()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('validateExportData', () => {
+    const validExportData: ExportData = {
+      version: '1.0',
+      export_timestamp: '2023-01-01T12:00:00Z',
+      reading_progress: [{
+        bookmark_id: 1,
+        progress: 0.5,
+        last_read_at: '2023-01-01T12:00:00Z',
+        reading_mode: 'readability',
+        scroll_position: 100,
+        dark_mode_override: null
+      }],
+      app_settings: {
+        sync_interval: 60,
+        auto_sync: true,
+        reading_mode: 'readability'
+      },
+      sync_metadata: {
+        last_sync_timestamp: '2023-01-01T10:00:00Z'
+      }
+    };
+
+    it('should validate correct export data', () => {
+      expect(ExportService.validateExportData(validExportData)).toBe(true);
+    });
+
+    it('should reject null or non-object data', () => {
+      expect(ExportService.validateExportData(null)).toBe(false);
+      expect(ExportService.validateExportData('string')).toBe(false);
+      expect(ExportService.validateExportData(123)).toBe(false);
+    });
+
+    it('should reject data missing required fields', () => {
+      const incompleteData = { ...validExportData };
+      delete (incompleteData as any).version;
+      expect(ExportService.validateExportData(incompleteData)).toBe(false);
+    });
+
+    it('should reject invalid reading progress entries', () => {
+      const invalidData = {
+        ...validExportData,
+        reading_progress: [{
+          bookmark_id: 'not-a-number',
+          progress: 0.5,
+          last_read_at: '2023-01-01T12:00:00Z',
+          reading_mode: 'readability',
+          scroll_position: 100
+        }]
+      };
+      expect(ExportService.validateExportData(invalidData)).toBe(false);
+    });
+
+    it('should reject invalid app settings', () => {
+      const invalidData = {
+        ...validExportData,
+        app_settings: {
+          sync_interval: 'not-a-number',
+          auto_sync: true,
+          reading_mode: 'readability'
+        }
+      };
+      expect(ExportService.validateExportData(invalidData)).toBe(false);
+    });
+
+    it('should accept valid dark mode override values', () => {
+      const validValues = [null, undefined, 'light', 'dark'];
+      
+      validValues.forEach(value => {
+        const testData = {
+          ...validExportData,
+          reading_progress: [{
+            ...validExportData.reading_progress[0],
+            dark_mode_override: value
+          }]
+        };
+        expect(ExportService.validateExportData(testData)).toBe(true);
+      });
+    });
+
+    it('should reject invalid dark mode override values', () => {
+      const invalidData = {
+        ...validExportData,
+        reading_progress: [{
+          ...validExportData.reading_progress[0],
+          dark_mode_override: 'invalid-mode'
+        }]
+      };
+      expect(ExportService.validateExportData(invalidData)).toBe(false);
+    });
+  });
+});

--- a/src/test/unit/import-service.test.ts
+++ b/src/test/unit/import-service.test.ts
@@ -1,0 +1,365 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { ImportService } from '../../services/import-service';
+import { ExportService, type ExportData } from '../../services/export-service';
+import { DatabaseService } from '../../services/database';
+
+// Mock the database module
+vi.mock('../../services/database', () => ({
+  DatabaseService: {
+    getBookmark: vi.fn(),
+    getReadProgress: vi.fn(),
+    saveReadProgress: vi.fn(),
+    getSettings: vi.fn(),
+    saveSettings: vi.fn(),
+    setLastSyncTimestamp: vi.fn()
+  }
+}));
+
+// Mock the export service
+vi.mock('../../services/export-service', () => ({
+  ExportService: {
+    validateExportData: vi.fn()
+  }
+}));
+
+describe('ImportService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const createMockExportData = (overrides: Partial<ExportData> = {}): ExportData => ({
+    version: '1.0',
+    export_timestamp: '2023-01-01T12:00:00Z',
+    reading_progress: [
+      {
+        bookmark_id: 1,
+        progress: 0.5,
+        last_read_at: '2023-01-01T12:00:00Z',
+        reading_mode: 'readability' as const,
+        scroll_position: 100,
+        dark_mode_override: null
+      },
+      {
+        bookmark_id: 2,
+        progress: 0.8,
+        last_read_at: '2023-01-02T12:00:00Z',
+        reading_mode: 'original' as const,
+        scroll_position: 200,
+        dark_mode_override: 'dark' as const
+      }
+    ],
+    app_settings: {
+      sync_interval: 30,
+      auto_sync: false,
+      reading_mode: 'original' as const,
+      theme_mode: 'light' as const
+    },
+    sync_metadata: {
+      last_sync_timestamp: '2023-01-01T10:00:00Z'
+    },
+    ...overrides
+  });
+
+  describe('importData', () => {
+    it('should successfully import all valid data', async () => {
+      const mockData = createMockExportData();
+      
+      // Mock validation
+      vi.mocked(ExportService.validateExportData).mockReturnValue(true);
+      
+      // Mock existing bookmarks
+      vi.mocked(DatabaseService.getBookmark).mockImplementation(async (id) => 
+        ({ id, url: `https://example.com/${id}`, title: `Bookmark ${id}` } as any)
+      );
+      
+      // Mock no existing reading progress
+      vi.mocked(DatabaseService.getReadProgress).mockResolvedValue(undefined);
+      
+      // Mock existing settings
+      vi.mocked(DatabaseService.getSettings).mockResolvedValue({
+        linkding_url: 'https://linkding.example.com',
+        linkding_token: 'existing-token',
+        sync_interval: 60,
+        auto_sync: true,
+        reading_mode: 'readability',
+        theme_mode: 'system'
+      });
+
+      const result = await ImportService.importData(mockData);
+
+      expect(result).toEqual({
+        success: true,
+        imported_progress_count: 2,
+        skipped_progress_count: 0,
+        imported_settings: true,
+        imported_sync_metadata: true,
+        errors: []
+      });
+
+      // Verify reading progress was saved
+      expect(DatabaseService.saveReadProgress).toHaveBeenCalledTimes(2);
+      expect(DatabaseService.saveReadProgress).toHaveBeenCalledWith(mockData.reading_progress[0]);
+      expect(DatabaseService.saveReadProgress).toHaveBeenCalledWith(mockData.reading_progress[1]);
+
+      // Verify settings were merged and saved
+      expect(DatabaseService.saveSettings).toHaveBeenCalledWith({
+        linkding_url: 'https://linkding.example.com', // Preserved
+        linkding_token: 'existing-token', // Preserved
+        sync_interval: 30, // From import
+        auto_sync: false, // From import
+        reading_mode: 'original', // From import
+        theme_mode: 'light' // From import
+      });
+
+      // Verify sync metadata was saved
+      expect(DatabaseService.setLastSyncTimestamp).toHaveBeenCalledWith('2023-01-01T10:00:00Z');
+    });
+
+    it('should skip orphaned reading progress (bookmark does not exist)', async () => {
+      const mockData = createMockExportData();
+      
+      vi.mocked(ExportService.validateExportData).mockReturnValue(true);
+      
+      // Mock bookmark 1 exists, bookmark 2 does not
+      vi.mocked(DatabaseService.getBookmark).mockImplementation(async (id) => 
+        id === 1 ? ({ id, url: `https://example.com/${id}`, title: `Bookmark ${id}` } as any) : undefined
+      );
+      
+      vi.mocked(DatabaseService.getReadProgress).mockResolvedValue(undefined);
+      vi.mocked(DatabaseService.getSettings).mockResolvedValue({
+        linkding_url: 'https://linkding.example.com',
+        linkding_token: 'existing-token',
+        sync_interval: 60,
+        auto_sync: true,
+        reading_mode: 'readability'
+      });
+
+      const result = await ImportService.importData(mockData);
+
+      expect(result.imported_progress_count).toBe(1);
+      expect(result.skipped_progress_count).toBe(1);
+      expect(result.success).toBe(true);
+      expect(DatabaseService.saveReadProgress).toHaveBeenCalledTimes(1);
+      expect(DatabaseService.saveReadProgress).toHaveBeenCalledWith(mockData.reading_progress[0]);
+    });
+
+    it('should skip reading progress when existing data is newer', async () => {
+      const mockData = createMockExportData();
+      
+      vi.mocked(ExportService.validateExportData).mockReturnValue(true);
+      vi.mocked(DatabaseService.getBookmark).mockImplementation(async (id) => 
+        ({ id, url: `https://example.com/${id}`, title: `Bookmark ${id}` } as any)
+      );
+      
+      // Mock existing reading progress with newer timestamp
+      vi.mocked(DatabaseService.getReadProgress).mockImplementation(async (bookmarkId) => {
+        if (bookmarkId === 1) {
+          return {
+            bookmark_id: 1,
+            progress: 0.6,
+            last_read_at: '2023-01-01T15:00:00Z', // Newer than import (12:00:00Z)
+            reading_mode: 'original',
+            scroll_position: 150,
+            dark_mode_override: null
+          };
+        }
+        return undefined; // No existing progress for bookmark 2
+      });
+      
+      vi.mocked(DatabaseService.getSettings).mockResolvedValue({
+        linkding_url: 'https://linkding.example.com',
+        linkding_token: 'existing-token',
+        sync_interval: 60,
+        auto_sync: true,
+        reading_mode: 'readability'
+      });
+
+      const result = await ImportService.importData(mockData);
+
+      expect(result.imported_progress_count).toBe(1); // Only bookmark 2
+      expect(result.skipped_progress_count).toBe(1); // Bookmark 1 skipped (existing newer)
+      expect(result.success).toBe(true);
+      expect(DatabaseService.saveReadProgress).toHaveBeenCalledTimes(1);
+      expect(DatabaseService.saveReadProgress).toHaveBeenCalledWith(mockData.reading_progress[1]);
+    });
+
+    it('should import reading progress when import data is newer', async () => {
+      const mockData = createMockExportData({
+        reading_progress: [{
+          bookmark_id: 1,
+          progress: 0.9,
+          last_read_at: '2023-01-01T15:00:00Z', // Newer timestamp
+          reading_mode: 'readability',
+          scroll_position: 300,
+          dark_mode_override: 'dark'
+        }]
+      });
+      
+      vi.mocked(ExportService.validateExportData).mockReturnValue(true);
+      vi.mocked(DatabaseService.getBookmark).mockResolvedValue({ id: 1, url: 'https://example.com/1', title: 'Bookmark 1' } as any);
+      
+      // Mock existing reading progress with older timestamp
+      vi.mocked(DatabaseService.getReadProgress).mockResolvedValue({
+        bookmark_id: 1,
+        progress: 0.5,
+        last_read_at: '2023-01-01T12:00:00Z', // Older than import (15:00:00Z)
+        reading_mode: 'original',
+        scroll_position: 100,
+        dark_mode_override: null
+      });
+      
+      vi.mocked(DatabaseService.getSettings).mockResolvedValue({
+        linkding_url: 'https://linkding.example.com',
+        linkding_token: 'existing-token',
+        sync_interval: 60,
+        auto_sync: true,
+        reading_mode: 'readability'
+      });
+
+      const result = await ImportService.importData(mockData);
+
+      expect(result.imported_progress_count).toBe(1);
+      expect(result.skipped_progress_count).toBe(0);
+      expect(result.success).toBe(true);
+      expect(DatabaseService.saveReadProgress).toHaveBeenCalledWith(mockData.reading_progress[0]);
+    });
+
+    it('should handle invalid export data', async () => {
+      const invalidData = { invalid: 'data' };
+      
+      vi.mocked(ExportService.validateExportData).mockReturnValue(false);
+
+      const result = await ImportService.importData(invalidData);
+
+      expect(result).toEqual({
+        success: false,
+        imported_progress_count: 0,
+        skipped_progress_count: 0,
+        imported_settings: false,
+        imported_sync_metadata: false,
+        errors: ['Invalid export data format']
+      });
+    });
+
+    it('should handle missing existing settings', async () => {
+      const mockData = createMockExportData();
+      
+      vi.mocked(ExportService.validateExportData).mockReturnValue(true);
+      vi.mocked(DatabaseService.getBookmark).mockResolvedValue({ id: 1 } as any);
+      vi.mocked(DatabaseService.getReadProgress).mockResolvedValue(undefined);
+      vi.mocked(DatabaseService.getSettings).mockResolvedValue(undefined); // No existing settings
+
+      const result = await ImportService.importData(mockData);
+
+      expect(result.imported_settings).toBe(false);
+      expect(result.errors).toContain('Failed to import settings: No existing settings found. Please configure Linkding server settings first.');
+    });
+
+    it('should handle database errors gracefully', async () => {
+      const mockData = createMockExportData();
+      
+      vi.mocked(ExportService.validateExportData).mockReturnValue(true);
+      vi.mocked(DatabaseService.getBookmark).mockRejectedValue(new Error('Database connection failed'));
+
+      const result = await ImportService.importData(mockData);
+
+      expect(result.success).toBe(false);
+      expect(result.imported_progress_count).toBe(0);
+      expect(result.skipped_progress_count).toBe(2); // Both failed
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors[0]).toContain('Database connection failed');
+    });
+  });
+
+  describe('importFromFile', () => {
+    it('should import data from valid JSON file', async () => {
+      const mockData = createMockExportData();
+      const jsonString = JSON.stringify(mockData);
+      const mockFile = new File([jsonString], 'export.json', { type: 'application/json' });
+
+      vi.mocked(ExportService.validateExportData).mockReturnValue(true);
+      vi.mocked(DatabaseService.getBookmark).mockResolvedValue({ id: 1 } as any);
+      vi.mocked(DatabaseService.getReadProgress).mockResolvedValue(undefined);
+      vi.mocked(DatabaseService.getSettings).mockResolvedValue({
+        linkding_url: 'https://linkding.example.com',
+        linkding_token: 'existing-token',
+        sync_interval: 60,
+        auto_sync: true,
+        reading_mode: 'readability'
+      });
+
+      const result = await ImportService.importFromFile(mockFile);
+
+      expect(result.success).toBe(true);
+      expect(result.imported_progress_count).toBe(2);
+    });
+
+    it('should handle invalid JSON file', async () => {
+      const mockFile = new File(['invalid json'], 'export.json', { type: 'application/json' });
+
+      const result = await ImportService.importFromFile(mockFile);
+
+      expect(result.success).toBe(false);
+      expect(result.errors[0]).toContain('Failed to read file');
+    });
+  });
+
+  describe('validateImportFile', () => {
+    it('should validate correct JSON file', async () => {
+      const mockData = createMockExportData();
+      const jsonString = JSON.stringify(mockData);
+      const mockFile = new File([jsonString], 'export.json', { type: 'application/json' });
+
+      vi.mocked(ExportService.validateExportData).mockReturnValue(true);
+
+      const result = await ImportService.validateImportFile(mockFile);
+
+      expect(result.valid).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it('should reject files that are too large', async () => {
+      const largeFile = new File(['x'.repeat(101 * 1024 * 1024)], 'large.json', { type: 'application/json' });
+
+      const result = await ImportService.validateImportFile(largeFile);
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('File too large (max 100MB)');
+    });
+
+    it('should reject non-JSON files', async () => {
+      const textFile = new File(['some text'], 'file.txt', { type: 'text/plain' });
+
+      const result = await ImportService.validateImportFile(textFile);
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('File must be a JSON file');
+    });
+
+    it('should reject files with invalid JSON content', async () => {
+      const invalidJsonFile = new File(['invalid json'], 'export.json', { type: 'application/json' });
+
+      const result = await ImportService.validateImportFile(invalidJsonFile);
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('Invalid file');
+    });
+
+    it('should reject files with invalid export data structure', async () => {
+      const invalidData = { version: '1.0', but: 'missing required fields' };
+      const jsonString = JSON.stringify(invalidData);
+      const mockFile = new File([jsonString], 'export.json', { type: 'application/json' });
+
+      vi.mocked(ExportService.validateExportData).mockReturnValue(false);
+
+      const result = await ImportService.validateImportFile(mockFile);
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('Invalid export file format');
+    });
+  });
+});


### PR DESCRIPTION
Implements issue #34 - export and import of reading progress and app settings.

Features:
- ExportService with modern File System Access API and fallback support
- ImportService with timestamp-based precedence for reading progress
- Settings panel UI integration with "Data Management" section
- Comprehensive test coverage (27 tests)
- Complete JSON schema documentation in README

Key implementation details:
- Uses ReadProgress last_read_at timestamps for import precedence
- Excludes cached assets and server credentials from export
- Handles orphaned progress and settings merging gracefully
- Supports streaming file processing where available

🤖 Generated with [Claude Code](https://claude.ai/code)