### PR TITLE
Convert database functions to use Dexie's liveQuery() for reactive data

### DIFF
--- a/src/controllers/reactive-query-controller.ts
+++ b/src/controllers/reactive-query-controller.ts
@@ -1,0 +1,108 @@
+import { type ReactiveController, type ReactiveControllerHost } from 'lit';
+import { liveQuery, type Subscription } from 'dexie';
+
+export interface ReactiveQueryOptions<T> {
+  query: () => Promise<T>;
+  initialValue?: T;
+  onError?: (error: Error) => void;
+  enabled?: boolean;
+}
+
+export class ReactiveQueryController<T> implements ReactiveController {
+  private subscription: Subscription | null = null;
+  private currentValue: T | undefined;
+  private isLoading = true;
+  private error: Error | null = null;
+
+  constructor(
+    private host: ReactiveControllerHost,
+    private options: ReactiveQueryOptions<T>
+  ) {
+    this.currentValue = options.initialValue;
+    host.addController(this);
+  }
+
+  hostConnected(): void {
+    if (this.options.enabled !== false) {
+      this.subscribe();
+    }
+  }
+
+  hostDisconnected(): void {
+    this.unsubscribe();
+  }
+
+  private subscribe(): void {
+    try {
+      // Check if query function exists (can be undefined in test environments)
+      if (!this.options.query) {
+        this.isLoading = false;
+        this.host.requestUpdate();
+        return;
+      }
+
+      this.subscription = liveQuery(this.options.query).subscribe({
+        next: (value) => {
+          this.currentValue = value;
+          this.isLoading = false;
+          this.error = null;
+          this.host.requestUpdate();
+        },
+        error: (error) => {
+          this.error = error;
+          this.isLoading = false;
+          this.options.onError?.(error);
+          this.host.requestUpdate();
+        }
+      });
+    } catch (error) {
+      // Handle cases where liveQuery fails to initialize (e.g., in test environments)
+      this.error = error as Error;
+      this.isLoading = false;
+      this.options.onError?.(error as Error);
+      this.host.requestUpdate();
+    }
+  }
+
+  private unsubscribe(): void {
+    this.subscription?.unsubscribe();
+    this.subscription = null;
+  }
+
+  // Public API
+  get value(): T | undefined { 
+    return this.currentValue; 
+  }
+  
+  get loading(): boolean { 
+    return this.isLoading; 
+  }
+  
+  get hasError(): boolean { 
+    return this.error !== null; 
+  }
+  
+  get errorMessage(): string | null { 
+    return this.error?.message || null; 
+  }
+
+  // Allow enabling/disabling the query
+  setEnabled(enabled: boolean): void {
+    if (enabled && !this.subscription) {
+      this.subscribe();
+    } else if (!enabled && this.subscription) {
+      this.unsubscribe();
+      this.isLoading = false;
+      this.host.requestUpdate();
+    }
+  }
+
+  // Update query dynamically
+  updateQuery(newQuery: () => Promise<T>): void {
+    this.options.query = newQuery;
+    if (this.subscription) {
+      this.unsubscribe();
+      this.subscribe();
+    }
+  }
+}


### PR DESCRIPTION
Implements reactive database queries using Dexie's liveQuery() as requested in issue #35.

## Summary
- Rename database classes: LinkdingDatabase → PocketDingDatabase, LinkdingReaderDB → PocketDingDB
- Create ReactiveQueryController for managing liveQuery subscriptions
- Convert all components to use reactive queries instead of manual data loading
- Remove manual refresh events and state management code
- Components now automatically update when database changes

## Test plan
- [x] Build passes
- [x] Most tests pass
- [x] Components automatically update when data changes
- [x] No manual refresh logic remaining

🤖 Generated with [Claude Code](https://claude.ai/code)