### PR TITLE
fix: Improve PWA manifest with consistent naming and enhanced metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <!-- iOS specific meta tags -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-    <meta name="apple-mobile-web-app-title" content="Linkding Reader" />
+    <meta name="apple-mobile-web-app-title" content="Pocket Ding" />
     
     <!-- Material Symbols font is now bundled locally via @fontsource/material-symbols-outlined -->
     <!-- See src/main.ts for font import -->

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig(({ command }) => {
         },
         manifest: {
           name: 'Pocket Ding',
-          short_name: 'LinkReader',
+          short_name: 'Pocket Ding',
           description: 'A PWA reader for Linkding bookmarks',
           theme_color: '#2563eb',
           background_color: '#ffffff',
@@ -31,16 +31,20 @@ export default defineConfig(({ command }) => {
           orientation: 'portrait',
           scope: base,
           start_url: base,
+          categories: ['productivity', 'utilities'],
+          lang: 'en',
           icons: [
             {
               src: base + 'icon-192.png',
               sizes: '192x192',
-              type: 'image/png'
+              type: 'image/png',
+              purpose: 'any maskable'
             },
             {
               src: base + 'icon-512.png',
               sizes: '512x512',
-              type: 'image/png'
+              type: 'image/png',
+              purpose: 'any maskable'
             }
           ]
         }


### PR DESCRIPTION
Fix PWA app name and icon display issues by improving VitePWA configuration:

- Change short_name from "LinkReader" to "Pocket Ding" for consistency
- Update Apple web app title to match app name "Pocket Ding"
- Add categories, language, and maskable icon support to PWA manifest
- Ensure consistent branding across all PWA installation contexts

Fixes #43

Generated with [Claude Code](https://claude.ai/code)