### PR TITLE
Fix badge and tag UI issues by replacing badges with icons

### DIFF
--- a/src/components/bookmark-list-container.ts
+++ b/src/components/bookmark-list-container.ts
@@ -350,7 +350,7 @@ export class BookmarkListContainer extends LitElement {
                 : 'Starting sync...'
               }
             </span>
-            <md-badge class="sync-badge" value="Syncing"></md-badge>
+            <md-icon class="sync-badge">sync</md-icon>
           </div>
           <md-linear-progress 
             .value=${syncState.syncTotal > 0 ? (syncState.syncProgress / syncState.syncTotal) : 0}

--- a/src/components/bookmark-list.ts
+++ b/src/components/bookmark-list.ts
@@ -191,8 +191,37 @@ export class BookmarkList extends LitElement {
     .bookmark-tags {
       display: flex;
       flex-wrap: wrap;
-      gap: 0.25rem;
+      gap: 0.5rem;
       margin-bottom: 0.5rem;
+    }
+
+    .tag-badge {
+      background: var(--md-sys-color-secondary-container);
+      color: var(--md-sys-color-on-secondary-container);
+      font-size: 0.75rem;
+      font-weight: 500;
+      padding: 0.25rem 0.5rem;
+      border-radius: 1rem;
+      white-space: nowrap;
+      border: 1px solid var(--md-sys-color-outline-variant);
+    }
+
+    .status-icons {
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+    }
+
+    .status-icon {
+      color: var(--md-sys-color-primary);
+    }
+
+    .status-icon.archived {
+      color: var(--md-sys-color-tertiary);
+    }
+
+    .status-icon.cached {
+      color: var(--md-sys-color-secondary);
     }
 
     .bookmark-progress {
@@ -490,17 +519,19 @@ export class BookmarkList extends LitElement {
           <div class="bookmark-header">
             <h3 class="bookmark-title md-typescale-title-medium">${bookmark.title}</h3>
             <div class="bookmark-meta">
-              ${bookmark.unread ? html`
-                <md-icon class="unread-icon" title="Unread">email</md-icon>
-              ` : html`
-                <md-icon class="read-icon" title="Read">drafts</md-icon>
-              `}
-              ${bookmark.is_archived ? html`
-                <md-badge value="Archived"></md-badge>
-              ` : ''}
-              ${this.bookmarksWithAssets.has(bookmark.id) ? html`
-                <md-badge value="Cached"></md-badge>
-              ` : ''}
+              <div class="status-icons">
+                ${bookmark.unread ? html`
+                  <md-icon class="unread-icon" title="Unread">email</md-icon>
+                ` : html`
+                  <md-icon class="read-icon" title="Read">drafts</md-icon>
+                `}
+                ${bookmark.is_archived ? html`
+                  <md-icon class="status-icon archived" title="Archived">archive</md-icon>
+                ` : ''}
+                ${this.bookmarksWithAssets.has(bookmark.id) ? html`
+                  <md-icon class="status-icon cached" title="Cached">download_done</md-icon>
+                ` : ''}
+              </div>
             </div>
           </div>
           
@@ -521,7 +552,7 @@ export class BookmarkList extends LitElement {
           ${bookmark.tag_names.length > 0 ? html`
             <div class="bookmark-tags">
               ${bookmark.tag_names.map(tag => html`
-                <md-badge value="${tag}"></md-badge>
+                <span class="tag-badge">${tag}</span>
               `)}
             </div>
           ` : ''}

--- a/src/test/unit/bookmark-list-presentation.test.ts
+++ b/src/test/unit/bookmark-list-presentation.test.ts
@@ -200,9 +200,9 @@ describe('BookmarkList', () => {
       const tags = element.shadowRoot?.querySelectorAll('.bookmark-tags');
       expect(tags).toHaveLength(2);
       
-      const firstBookmarkTags = tags?.[0]?.querySelectorAll('md-badge');
+      const firstBookmarkTags = tags?.[0]?.querySelectorAll('.tag-badge');
       expect(firstBookmarkTags).toHaveLength(1);
-      expect(firstBookmarkTags?.[0]?.getAttribute('value')).toBe('test');
+      expect(firstBookmarkTags?.[0]?.textContent).toBe('test');
     });
 
     it('should show read/unread status correctly', async () => {
@@ -225,6 +225,72 @@ describe('BookmarkList', () => {
       const readIcon = element.shadowRoot?.querySelector('.bookmark-card:last-child .read-icon');
       expect(readIcon).toBeTruthy();
       expect(readIcon?.textContent).toBe('drafts');
+    });
+
+    it('should show archive icon for archived bookmarks', async () => {
+      // Create archived bookmark
+      const archivedBookmark: LocalBookmark[] = [
+        {
+          ...mockBookmarks[0],
+          id: 3,
+          is_archived: true,
+        } as LocalBookmark
+      ];
+
+      element = new BookmarkList();
+      element.bookmarks = archivedBookmark;
+      element.isLoading = false;
+      element.bookmarksWithAssets = new Set();
+      element.faviconCache = new Map();
+      element.syncedBookmarkIds = new Set();
+      element.paginationState = {
+        currentPage: 1,
+        pageSize: 25,
+        totalCount: 1,
+        totalPages: 1,
+        filter: 'archived' // Use archived filter to show archived bookmarks
+      };
+      
+      document.body.appendChild(element);
+      await element.updateComplete;
+      
+      // Should have archive icon
+      const archivedIcon = element.shadowRoot?.querySelector('.bookmark-card:first-child .status-icon.archived');
+      expect(archivedIcon).toBeTruthy();
+      expect(archivedIcon?.textContent).toBe('archive');
+    });
+
+    it('should show cached icon for bookmarks with assets', async () => {
+      // Create non-archived bookmark
+      const cachedBookmark: LocalBookmark[] = [
+        {
+          ...mockBookmarks[1],
+          id: 4,
+          is_archived: false,
+        } as LocalBookmark
+      ];
+
+      element = new BookmarkList();
+      element.bookmarks = cachedBookmark;
+      element.isLoading = false;
+      element.bookmarksWithAssets = new Set([4]); // Mark bookmark as cached
+      element.faviconCache = new Map();
+      element.syncedBookmarkIds = new Set();
+      element.paginationState = {
+        currentPage: 1,
+        pageSize: 25,
+        totalCount: 1,
+        totalPages: 1,
+        filter: 'all' // Use all filter for non-archived bookmarks
+      };
+      
+      document.body.appendChild(element);
+      await element.updateComplete;
+      
+      // Should have cached icon
+      const cachedIcon = element.shadowRoot?.querySelector('.bookmark-card:first-child .status-icon.cached');
+      expect(cachedIcon).toBeTruthy();
+      expect(cachedIcon?.textContent).toBe('download_done');
     });
   });
 });

--- a/src/test/unit/bookmark-list-sync.test.ts
+++ b/src/test/unit/bookmark-list-sync.test.ts
@@ -328,10 +328,10 @@ describe('BookmarkListContainer Background Sync', () => {
       await new Promise(resolve => setTimeout(resolve, 10));
       await element.updateComplete;
 
-      // Check for cached badge
+      // Check for cached icon
       const presentationComponent = getPresentationComponent();
-      const cachedBadge = [...(presentationComponent?.shadowRoot?.querySelectorAll('md-badge') || [])].find(badge => badge.getAttribute('value') === 'Cached');
-      expect(cachedBadge).toBeTruthy();
+      const cachedIcon = presentationComponent?.shadowRoot?.querySelector('.status-icon.cached');
+      expect(cachedIcon).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
Fixes #51

Converted status badges to Material icons and improved tag styling for better visual hierarchy and user experience.

## Changes
- Replace Archived/Cached/Syncing badges with Material icons
- Improve tag spacing, styling, and prevent truncation
- Add clear visual separation between status and content
- Update tests to match new implementation
- All tests pass and build succeeds

Generated with [Claude Code](https://claude.ai/code)