### PR TITLE
fix: constrain content source dropdown width to prevent overflow

### DIFF
--- a/src/components/bookmark-reader.ts
+++ b/src/components/bookmark-reader.ts
@@ -68,6 +68,7 @@ export class BookmarkReader extends LitElement {
 
     .content-source-selector {
       min-width: 120px;
+      max-width: 200px;
     }
 
     .toolbar-section {
@@ -330,6 +331,11 @@ export class BookmarkReader extends LitElement {
         flex-wrap: nowrap;
         min-height: 2.75rem; /* 44px - reduced from 3rem */
         gap: 0.25rem;
+      }
+      
+      .content-source-selector {
+        min-width: 80px;
+        max-width: 140px;
       }
       
       .progress-section {


### PR DESCRIPTION
Fixes #52 (follow-up)

This PR fixes the remaining dropdown text overflow issue identified after the initial header height optimization.

## Problem

The content source selector dropdown was allowing unlimited width expansion, causing long text labels like "HTML snapshot from 08/05/2025" to overflow and break the compact header layout.

## Solution

**Desktop Constraints:**
- Added `max-width: 200px` to content-source-selector
- Maintains `min-width: 120px` for usability

**Mobile Constraints:**
- Added `max-width: 140px` for tighter mobile layout
- Maintains `min-width: 80px` for touch targets

**Text Handling:**
- Material Web Components automatically handle text truncation with ellipsis
- All dropdown options remain functional and selectable

## Result

- ✅ Prevents dropdown overflow that was breaking header layout
- ✅ Maintains the compact header height optimization from previous work
- ✅ Preserves full functionality with improved visual design
- ✅ Responsive design with appropriate constraints for all screen sizes

Generated with [Claude Code](https://claude.ai/code)