### PR TITLE
Make reader toolbar progress section more responsive

### DIFF
--- a/src/components/bookmark-reader.ts
+++ b/src/components/bookmark-reader.ts
@@ -94,14 +94,16 @@ export class BookmarkReader extends LitElement {
       display: flex;
       align-items: center;
       gap: 0.75rem;
+      flex-shrink: 0;
     }
 
     .progress-section {
       display: flex;
       align-items: center;
       gap: 0.5rem;
-      flex: 1;
+      flex: 1 1 0;
       min-width: 0;
+      overflow: hidden;
     }
 
     .progress-text {
@@ -111,6 +113,7 @@ export class BookmarkReader extends LitElement {
       color: var(--md-sys-color-on-surface-variant);
       white-space: nowrap;
       font-weight: 500;
+      flex-shrink: 0;
     }
 
     .reader-content {
@@ -322,8 +325,9 @@ export class BookmarkReader extends LitElement {
         /* order: 3; */
         /* flex-basis: 100%; */
         /* margin-top: 0.5rem; */
-        flex: 1;
+        flex: 1 1 0;
         min-width: 0;
+        overflow: hidden;
       }
       
       .toolbar-section {
@@ -920,12 +924,14 @@ export class BookmarkReader extends LitElement {
           </div>
           
           <!-- Open External Link -->
-          <md-icon-button
-            @click=${this.handleOpenOriginal}
-            title="Open original website"
-          >
-            <md-icon>open_in_new</md-icon>
-          </md-icon-button>
+          <div style="flex-shrink: 0;">
+            <md-icon-button
+              @click=${this.handleOpenOriginal}
+              title="Open original website"
+            >
+              <md-icon>open_in_new</md-icon>
+            </md-icon-button>
+          </div>
         </div>
         
         <div class="reader-content">


### PR DESCRIPTION
Fixes #69

Replace fixed max-width constraints with flexible flex properties that allow the progress section to take available space after fixed components (buttons) have taken their required space.

## Changes
- Progress section uses flex: 1 1 0 with overflow: hidden for better space distribution
- Progress text has flex-shrink: 0 to maintain readability
- Left toolbar section and open button have flex-shrink: 0 to maintain fixed space
- Applied responsive approach to both desktop and mobile breakpoints

This prevents the progress bar from overlapping the "open in new" button while still allowing it to use available space responsively.

🤖 Generated with [Claude Code](https://claude.ai/code)