### PR TITLE
Fix non-tappable links in error screens on mobile

### DIFF
--- a/src/services/content-fetcher.ts
+++ b/src/services/content-fetcher.ts
@@ -187,11 +187,19 @@ export class ContentFetcher {
         }
         
         .primary-button, .secondary-button {
+          display: inline-block;
           padding: 0.75rem 1.5rem;
           border-radius: 24px;
           text-decoration: none;
           font-weight: 500;
           transition: background-color 0.2s ease;
+          cursor: pointer;
+          touch-action: manipulation;
+          -webkit-tap-highlight-color: transparent;
+          user-select: none;
+          min-height: 44px;
+          min-width: 44px;
+          box-sizing: border-box;
         }
         
         .primary-button {
@@ -199,7 +207,7 @@ export class ContentFetcher {
           color: var(--md-sys-color-on-primary);
         }
         
-        .primary-button:hover {
+        .primary-button:hover, .primary-button:focus, .primary-button:active {
           background: var(--md-sys-color-primary-container);
           color: var(--md-sys-color-on-primary-container);
         }
@@ -209,7 +217,7 @@ export class ContentFetcher {
           color: var(--md-sys-color-on-secondary-container);
         }
         
-        .secondary-button:hover {
+        .secondary-button:hover, .secondary-button:focus, .secondary-button:active {
           background: var(--md-sys-color-secondary);
           color: var(--md-sys-color-on-secondary);
         }
@@ -574,11 +582,19 @@ export class ContentFetcher {
         }
         
         .primary-button, .secondary-button {
+          display: inline-block;
           padding: 0.75rem 1.5rem;
           border-radius: 24px;
           text-decoration: none;
           font-weight: 500;
           transition: background-color 0.2s ease;
+          cursor: pointer;
+          touch-action: manipulation;
+          -webkit-tap-highlight-color: transparent;
+          user-select: none;
+          min-height: 44px;
+          min-width: 44px;
+          box-sizing: border-box;
         }
         
         .primary-button {
@@ -586,7 +602,7 @@ export class ContentFetcher {
           color: var(--md-sys-color-on-primary);
         }
         
-        .primary-button:hover {
+        .primary-button:hover, .primary-button:focus, .primary-button:active {
           background: var(--md-sys-color-primary-container);
           color: var(--md-sys-color-on-primary-container);
         }
@@ -596,7 +612,7 @@ export class ContentFetcher {
           color: var(--md-sys-color-on-secondary-container);
         }
         
-        .secondary-button:hover {
+        .secondary-button:hover, .secondary-button:focus, .secondary-button:active {
           background: var(--md-sys-color-secondary);
           color: var(--md-sys-color-on-secondary);
         }


### PR DESCRIPTION
Fixes #74

This PR addresses the issue where "Open Original Website" and "Try Web Archive Version" links weren't tappable on mobile devices in error screens like "Live URL Content Unavailable".

## Changes
- Added proper mobile touch support to action buttons
- Used `touch-action: manipulation` for better touch handling
- Added minimum touch target size (44px) for accessibility
- Removed tap highlights and prevented text selection
- Extended hover styles to focus/active for touch feedback

## Testing
- All existing tests pass
- Build successful

Generated with [Claude Code](https://claude.ai/code)