### PR TITLE
Refactor ContentFetcher to separate data fetching from HTML generation

### DIFF
--- a/src/test/integration/dark-mode-integration.test.ts
+++ b/src/test/integration/dark-mode-integration.test.ts
@@ -95,9 +95,10 @@ describe('Dark Mode Integration', () => {
       { type: 'asset', label: 'Cached Content', assetId: 1 }
     ]);
     vi.mocked(ContentFetcher.fetchBookmarkContent).mockResolvedValue({
-      content: '<p>Test content</p>',
-      readability_content: '<p>Readability content</p>',
-      source: 'asset'
+      source: 'asset',
+      content_type: 'html',
+      html_content: '<p>Test content</p>',
+      readability_content: '<p>Readability content</p>'
     });
 
     // Create reader element

--- a/src/test/integration/reading-progress-integration.test.ts
+++ b/src/test/integration/reading-progress-integration.test.ts
@@ -92,9 +92,10 @@ describe('Reading Progress Integration Tests', () => {
 
   const createElementWithContent = async (content: string) => {
     vi.mocked(ContentFetcher.fetchBookmarkContent).mockResolvedValue({
-      content,
-      readability_content: content,
-      source: 'asset'
+      source: 'asset',
+      content_type: 'html',
+      html_content: content,
+      readability_content: content
     });
 
     element = new BookmarkReader();
@@ -544,9 +545,13 @@ describe('Reading Progress Integration Tests', () => {
         </div>
       `;
       
-      // Update the component's content directly
-      (element as any).currentContent = content;
-      (element as any).currentReadabilityContent = content;
+      // Update the component's content directly via contentResult
+      (element as any).contentResult = {
+        source: 'asset' as const,
+        content_type: 'html' as const,
+        html_content: content,
+        readability_content: content
+      };
       
       // Trigger re-render
       await element.updateComplete;
@@ -606,9 +611,10 @@ describe('Reading Progress Integration Tests', () => {
       
       // Create element manually without using createElementWithContent to avoid the error in setup
       vi.mocked(ContentFetcher.fetchBookmarkContent).mockResolvedValue({
-        content,
-        readability_content: content,
-        source: 'asset'
+        source: 'asset',
+        content_type: 'html',
+        html_content: content,
+        readability_content: content
       });
 
       element = new BookmarkReader();
@@ -658,9 +664,10 @@ describe('Reading Progress Integration Tests', () => {
       `;
 
       vi.mocked(ContentFetcher.fetchBookmarkContent).mockResolvedValue({
-        content: originalContent,
-        readability_content: readabilityContent,
-        source: 'asset'
+        source: 'asset',
+        content_type: 'html',
+        html_content: originalContent,
+        readability_content: readabilityContent
       });
 
       await createElementWithContent(originalContent);

--- a/src/test/unit/bookmark-reader-asset-selection.test.ts
+++ b/src/test/unit/bookmark-reader-asset-selection.test.ts
@@ -51,15 +51,17 @@ describe('BookmarkReader - Asset Selection', () => {
     vi.mocked(ContentFetcher.fetchBookmarkContent).mockImplementation(async (_bookmark, source) => {
       if (source === 'url') {
         return {
-          content: '<div>Live URL content</div>',
-          readability_content: '<div>Live readable content</div>',
-          source: 'url'
+          source: 'url',
+          content_type: 'html',
+          html_content: '<div>Live URL content</div>',
+          readability_content: '<div>Live readable content</div>'
         };
       }
       return {
-        content: '<div>Test content</div>',
-        readability_content: '<div>Readable content</div>',
-        source: 'asset'
+        source: 'asset',
+        content_type: 'html',
+        html_content: '<div>Test content</div>',
+        readability_content: '<div>Readable content</div>'
       };
     });
 

--- a/src/test/unit/bookmark-reader-dark-mode.test.ts
+++ b/src/test/unit/bookmark-reader-dark-mode.test.ts
@@ -60,9 +60,10 @@ describe('BookmarkReader Dark Mode', () => {
       { type: 'asset', label: 'Cached Content', assetId: 1 }
     ]);
     vi.mocked(ContentFetcher.fetchBookmarkContent).mockResolvedValue({
-      content: '<p>Test content</p>',
-      readability_content: '<p>Readability content</p>',
-      source: 'asset'
+      source: 'asset',
+      content_type: 'html',
+      html_content: '<p>Test content</p>',
+      readability_content: '<p>Readability content</p>'
     });
 
     // Mock ThemeService

--- a/src/test/unit/bookmark-reader-info-modal.test.ts
+++ b/src/test/unit/bookmark-reader-info-modal.test.ts
@@ -62,9 +62,10 @@ describe('BookmarkReader - Info Modal', () => {
     vi.mocked(DatabaseService.saveBookmark).mockResolvedValue();
     vi.mocked(ContentFetcher.getAvailableContentSources).mockResolvedValue(contentSources);
     vi.mocked(ContentFetcher.fetchBookmarkContent).mockResolvedValue({
-      content: '<div>Test content</div>',
-      readability_content: '<div>Readable content</div>',
-      source: 'asset'
+      source: 'asset',
+      content_type: 'html',
+      html_content: '<div>Test content</div>',
+      readability_content: '<div>Readable content</div>'
     });
 
     // Create element

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -81,6 +81,32 @@ export interface ContentSourceOption {
   assetId?: number;
 }
 
+// Content fetcher result types - structured data instead of HTML
+export interface ContentResult {
+  source: ContentSource;
+  content_type: 'html' | 'iframe' | 'error' | 'unsupported';
+  html_content?: string;
+  readability_content?: string | null;
+  iframe_url?: string;
+  error?: ContentError;
+  metadata?: ContentMetadata;
+}
+
+export interface ContentError {
+  type: 'cors' | 'network' | 'not_found' | 'unsupported' | 'server_error';
+  message: string;
+  details?: string;
+  suggestions?: string[];
+}
+
+export interface ContentMetadata {
+  content_type?: string;
+  file_size?: number;
+  asset_id?: number;
+  display_name?: string;
+  url?: string;
+}
+
 export type ThemeMode = 'light' | 'dark' | 'system';
 
 // BookmarkList Container/Presentation Component Types


### PR DESCRIPTION
Fixes #67

This refactoring improves separation of concerns by moving HTML generation from the ContentFetcher service to the BookmarkReader component.

## Changes
- ContentFetcher now returns structured ContentResult objects instead of HTML
- Added ContentResult, ContentError, and ContentMetadata types
- BookmarkReader generates HTML for error states, iframe content, and unsupported content
- Removed 350+ lines of HTML/CSS generation code from ContentFetcher
- Live URL now uses iframe approach to bypass CORS issues completely
- Updated all tests to work with new structured data format

## Benefits
- Clean separation between data layer and presentation layer
- Better error handling with structured error types and suggestions
- Eliminates CORS issues for Live URL viewing
- More testable and maintainable architecture
- Consistent error UI handled by components

🤖 Generated with [Claude Code](https://claude.ai/code)