### PR TITLE
Fix sync button event handling

### DIFF
--- a/src/components/bookmark-list-container.ts
+++ b/src/components/bookmark-list-container.ts
@@ -116,11 +116,13 @@ export class BookmarkListContainer extends LitElement {
     super.connectedCallback();
     // StateController automatically handles persistence via observedProperties
     void this.stateController; // Suppress TS6133: declared but never read warning
+    this.addEventListener('sync-requested', this.handleSyncRequested);
     this.loadBookmarks();
   }
 
   override disconnectedCallback() {
     super.disconnectedCallback();
+    this.removeEventListener('sync-requested', this.handleSyncRequested);
   }
 
 


### PR DESCRIPTION
Fixes sync button not working by adding missing event listener in bookmark-list-container.

The sync button was dispatching sync-requested events but the container wasn't listening for them.

Fixes #77

🤖 Generated with [Claude Code](https://claude.ai/code)