### PR TITLE
fix: dark mode button now applies styles to readability iframe content

### DIFF
--- a/src/components/bookmark-reader.ts
+++ b/src/components/bookmark-reader.ts
@@ -987,6 +987,7 @@ export class BookmarkReader extends LitElement {
           class="secure-iframe"
           .content=${content}
           .scrollPosition=${this.scrollPosition}
+          .isDarkMode=${this.darkModeOverride === 'dark' || (this.darkModeOverride === null && this.systemTheme === 'dark')}
           @progress-update=${this.handleIframeProgressUpdate}
           @content-loaded=${this.handleIframeContentLoaded}
           @content-error=${this.handleIframeContentError}

--- a/src/components/secure-iframe.ts
+++ b/src/components/secure-iframe.ts
@@ -8,6 +8,7 @@ export class SecureIframe extends LitElement {
   @property({ type: Boolean }) isLoading = false;
   @property({ type: Function }) onContentLoad: () => void = () => {};
   @property({ type: Function }) onContentError: (error: string) => void = () => {};
+  @property({ type: Boolean }) isDarkMode = false;
 
   @property({ type: Number }) scrollPosition = 0;
 
@@ -90,7 +91,7 @@ export class SecureIframe extends LitElement {
   }
 
   override updated(changedProperties: Map<string, any>) {
-    if (changedProperties.has('content') && this.content) {
+    if ((changedProperties.has('content') && this.content) || changedProperties.has('isDarkMode')) {
       this.processContent();
     }
   }
@@ -139,7 +140,8 @@ export class SecureIframe extends LitElement {
 
     try {
       this.secureContent = await SecurityService.prepareSingleFileContent(
-        this.content
+        this.content,
+        this.isDarkMode
       );
       await this.updateComplete;
       this.setupIframe();

--- a/src/services/security-service.ts
+++ b/src/services/security-service.ts
@@ -8,7 +8,8 @@ export class SecurityService {
    * Uses DOMParser approach as specified in requirements
    */
   static async prepareSingleFileContent(
-    singleFileHtml: string
+    singleFileHtml: string,
+    isDarkMode: boolean = false
   ): Promise<string> {
     let contentToProcess = singleFileHtml;
     
@@ -39,6 +40,11 @@ export class SecurityService {
     // Add CSP meta tag to head
     this.injectCSP(doc);
     
+    // Add dark mode CSS if enabled
+    if (isDarkMode) {
+      this.injectDarkModeCSS(doc);
+    }
+    
     // Add progress tracking script to body
     this.injectProgressTracking(doc);
     
@@ -68,6 +74,69 @@ export class SecurityService {
       "media-src 'none';"
     );
     doc.head.appendChild(cspMeta);
+  }
+
+  /**
+   * Injects dark mode CSS styles into document head
+   */
+  private static injectDarkModeCSS(doc: Document): void {
+    const darkModeStyle = doc.createElement('style');
+    darkModeStyle.textContent = `
+      /* Dark mode styles for readability content */
+      body {
+        background: #121212 !important;
+        color: #e0e0e0 !important;
+      }
+      
+      h1, h2, h3, h4, h5, h6 {
+        color: #ffffff !important;
+      }
+      
+      p, div, span, li {
+        color: #e0e0e0 !important;
+      }
+      
+      a {
+        color: #bb86fc !important;
+      }
+      
+      a:visited {
+        color: #cf6679 !important;
+      }
+      
+      blockquote {
+        background: #1e1e1e !important;
+        border-left-color: #bb86fc !important;
+        color: #e0e0e0 !important;
+      }
+      
+      pre, code {
+        background: #1e1e1e !important;
+        color: #e0e0e0 !important;
+        border: 1px solid #333 !important;
+      }
+      
+      table {
+        background: #121212 !important;
+        color: #e0e0e0 !important;
+        border-color: #333 !important;
+      }
+      
+      th, td {
+        background: #1e1e1e !important;
+        color: #e0e0e0 !important;
+        border-color: #333 !important;
+      }
+      
+      hr {
+        border-color: #333 !important;
+      }
+      
+      img {
+        opacity: 0.8;
+      }
+    `;
+    doc.head.appendChild(darkModeStyle);
   }
 
   /**

--- a/src/test/integration/secure-iframe-integration.test.ts
+++ b/src/test/integration/secure-iframe-integration.test.ts
@@ -60,7 +60,7 @@ describe('Secure Iframe Integration', () => {
       document.body.appendChild(iframe);
       await iframe.updateComplete;
       
-      expect(SecurityService.prepareSingleFileContent).toHaveBeenCalledWith(mockSingleFileContent);
+      expect(SecurityService.prepareSingleFileContent).toHaveBeenCalledWith(mockSingleFileContent, false);
     });
 
     it('should create iframe with proper sandbox attributes', async () => {
@@ -271,7 +271,39 @@ describe('Secure Iframe Integration', () => {
       document.body.appendChild(iframe);
       await iframe.updateComplete;
       
-      expect(SecurityService.prepareSingleFileContent).toHaveBeenCalledWith(maliciousContent);
+      expect(SecurityService.prepareSingleFileContent).toHaveBeenCalledWith(maliciousContent, false);
+    });
+
+  });
+
+  describe('Dark Mode Integration', () => {
+    it('should pass dark mode state to SecurityService', async () => {
+      iframe = new SecureIframe();
+      iframe.content = mockSingleFileContent;
+      iframe.isDarkMode = true;
+      
+      document.body.appendChild(iframe);
+      await iframe.updateComplete;
+      
+      expect(SecurityService.prepareSingleFileContent).toHaveBeenCalledWith(mockSingleFileContent, true);
+    });
+
+    it('should reprocess content when dark mode changes', async () => {
+      iframe = new SecureIframe();
+      iframe.content = mockSingleFileContent;
+      iframe.isDarkMode = false;
+      
+      document.body.appendChild(iframe);
+      await iframe.updateComplete;
+      
+      expect(SecurityService.prepareSingleFileContent).toHaveBeenCalledWith(mockSingleFileContent, false);
+      
+      // Change dark mode and verify content is reprocessed
+      vi.mocked(SecurityService.prepareSingleFileContent).mockClear();
+      iframe.isDarkMode = true;
+      await iframe.updateComplete;
+      
+      expect(SecurityService.prepareSingleFileContent).toHaveBeenCalledWith(mockSingleFileContent, true);
     });
 
   });

--- a/src/test/playwright/iframe-dark-mode-visual.spec.ts
+++ b/src/test/playwright/iframe-dark-mode-visual.spec.ts
@@ -1,0 +1,363 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Iframe Dark Mode Visual Integration', () => {
+  test('visually confirms iframe content uses dark theme styles', async ({ page }) => {
+    // Navigate to app
+    await page.goto('/');
+    
+    // Wait for app to load
+    await page.waitForSelector('app-root');
+    
+    // Enable mock mode to avoid external API dependencies
+    await page.evaluate(() => {
+      localStorage.setItem('mockMode', 'true');
+    });
+    
+    await page.reload();
+    await page.waitForSelector('bookmark-list', { timeout: 15000 });
+    
+    // Inject a test bookmark with rich content for visual validation
+    await page.evaluate(() => {
+      const mockBookmark = {
+        id: 999,
+        url: 'https://example.com/dark-mode-test',
+        title: 'Dark Mode Visual Test Article',
+        content: `
+          <h1>Main Heading</h1>
+          <h2>Secondary Heading</h2>
+          <p>This is a paragraph of normal text content that should appear in light gray color in dark mode.</p>
+          <p>Here's another paragraph with <a href="#">a link that should be purple</a> and some <code>inline code</code>.</p>
+          <blockquote>
+            <p>This is a blockquote that should have a dark background with purple left border.</p>
+          </blockquote>
+          <pre><code>
+function darkModeTest() {
+  // This code block should have dark background
+  return 'success';
+}
+          </code></pre>
+          <ul>
+            <li>First list item</li>
+            <li>Second list item with <a href="#" target="_blank">external link</a></li>
+          </ul>
+          <table>
+            <thead>
+              <tr>
+                <th>Column 1</th>
+                <th>Column 2</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Cell 1</td>
+                <td>Cell 2</td>
+              </tr>
+              <tr>
+                <td>Cell 3</td>
+                <td>Cell 4</td>
+              </tr>
+            </tbody>
+          </table>
+          <hr>
+          <p>Final paragraph after horizontal rule.</p>
+        `,
+        readability_content: `
+          <h1>Main Heading</h1>
+          <h2>Secondary Heading</h2>
+          <p>This is a paragraph of normal text content that should appear in light gray color in dark mode.</p>
+          <p>Here's another paragraph with <a href="#">a link that should be purple</a> and some <code>inline code</code>.</p>
+          <blockquote>
+            <p>This is a blockquote that should have a dark background with purple left border.</p>
+          </blockquote>
+          <pre><code>
+function darkModeTest() {
+  // This code block should have dark background
+  return 'success';
+}
+          </code></pre>
+          <ul>
+            <li>First list item</li>
+            <li>Second list item with <a href="#" target="_blank">external link</a></li>
+          </ul>
+          <table>
+            <thead>
+              <tr>
+                <th>Column 1</th>
+                <th>Column 2</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Cell 1</td>
+                <td>Cell 2</td>
+              </tr>
+              <tr>
+                <td>Cell 3</td>
+                <td>Cell 4</td>
+              </tr>
+            </tbody>
+          </table>
+          <hr>
+          <p>Final paragraph after horizontal rule.</p>
+        `,
+        is_archived: false,
+        unread: true,
+        created: '2024-01-01T00:00:00Z',
+        description: 'Test article for dark mode visual validation'
+      };
+      
+      // Store the test bookmark in IndexedDB via the mock system
+      if (typeof window !== 'undefined' && (window as any).mockBookmarks) {
+        (window as any).mockBookmarks.push(mockBookmark);
+      }
+    });
+    
+    // Navigate to the test bookmark
+    await page.goto(`/#/reader/999`);
+    
+    // Wait for the reader to load
+    await page.waitForSelector('bookmark-reader', { timeout: 10000 });
+    
+    // Ensure we're in readability mode
+    await page.waitForSelector('secure-iframe', { timeout: 10000 });
+    
+    // Wait for iframe content to load
+    await page.waitForTimeout(2000);
+    
+    // Enable dark mode by clicking the dark mode toggle
+    const darkModeButton = page.locator('md-icon-button[title*="Mode"]').first();
+    await expect(darkModeButton).toBeVisible();
+    
+    // Click to activate dark mode
+    await darkModeButton.click();
+    await page.waitForTimeout(1000); // Allow dark mode to apply
+    
+    // Take a screenshot to visually confirm dark mode is active in the iframe
+    await page.screenshot({ 
+      path: 'src/test/playwright/images/iframe-dark-mode-applied.png', 
+      fullPage: true 
+    });
+    
+    // Get the iframe element
+    const iframe = page.locator('secure-iframe iframe').first();
+    await expect(iframe).toBeVisible();
+    
+    // Access iframe content and validate dark mode styles are applied
+    const iframeHandle = await iframe.elementHandle();
+    if (!iframeHandle) {
+      throw new Error('Could not get iframe element handle');
+    }
+    
+    const iframeContent = await iframeHandle.contentFrame();
+    if (!iframeContent) {
+      throw new Error('Could not access iframe content');
+    }
+    
+    // Check body background color (should be dark: #121212)
+    const bodyBgColor = await iframeContent.evaluate(() => {
+      const body = document.body;
+      return window.getComputedStyle(body).backgroundColor;
+    });
+    
+    // Check body text color (should be light: #e0e0e0)
+    const bodyTextColor = await iframeContent.evaluate(() => {
+      const body = document.body;
+      return window.getComputedStyle(body).color;
+    });
+    
+    // Check h1 color (should be white: #ffffff)
+    const h1Color = await iframeContent.evaluate(() => {
+      const h1 = document.querySelector('h1');
+      if (!h1) return 'not-found';
+      return window.getComputedStyle(h1).color;
+    });
+    
+    // Check paragraph color (should be light gray: #e0e0e0)
+    const pColor = await iframeContent.evaluate(() => {
+      const p = document.querySelector('p');
+      if (!p) return 'not-found';
+      return window.getComputedStyle(p).color;
+    });
+    
+    // Check link color (should be purple: #bb86fc)
+    const linkColor = await iframeContent.evaluate(() => {
+      const link = document.querySelector('a');
+      if (!link) return 'not-found';
+      return window.getComputedStyle(link).color;
+    });
+    
+    // Check blockquote background (should be dark: #1e1e1e)
+    const blockquoteBgColor = await iframeContent.evaluate(() => {
+      const blockquote = document.querySelector('blockquote');
+      if (!blockquote) return 'not-found';
+      return window.getComputedStyle(blockquote).backgroundColor;
+    });
+    
+    // Check code background (should be dark: #1e1e1e)
+    const codeBgColor = await iframeContent.evaluate(() => {
+      const code = document.querySelector('code');
+      if (!code) return 'not-found';
+      return window.getComputedStyle(code).backgroundColor;
+    });
+    
+    // Validate dark mode colors are applied
+    // Note: RGB values may be computed differently by different browsers,
+    // so we check for dark backgrounds and light text
+    console.log('Body background:', bodyBgColor);
+    console.log('Body text color:', bodyTextColor);
+    console.log('H1 color:', h1Color);
+    console.log('Paragraph color:', pColor);
+    console.log('Link color:', linkColor);
+    console.log('Blockquote background:', blockquoteBgColor);
+    console.log('Code background:', codeBgColor);
+    
+    // Convert RGB to validate dark theme
+    const rgbToValues = (rgb: string) => {
+      const match = rgb.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
+      if (!match || !match[1] || !match[2] || !match[3]) return null;
+      return [parseInt(match[1]), parseInt(match[2]), parseInt(match[3])];
+    };
+    
+    // Validate body background is very dark (close to #121212 which is rgb(18, 18, 18))
+    const bodyBg = rgbToValues(bodyBgColor);
+    if (bodyBg) {
+      expect(bodyBg[0]).toBeLessThan(50); // R should be very low
+      expect(bodyBg[1]).toBeLessThan(50); // G should be very low  
+      expect(bodyBg[2]).toBeLessThan(50); // B should be very low
+    }
+    
+    // Validate body text color is light (close to #e0e0e0 which is rgb(224, 224, 224))
+    const bodyText = rgbToValues(bodyTextColor);
+    if (bodyText) {
+      expect(bodyText[0]).toBeGreaterThan(200); // R should be high
+      expect(bodyText[1]).toBeGreaterThan(200); // G should be high
+      expect(bodyText[2]).toBeGreaterThan(200); // B should be high
+    }
+    
+    // Validate h1 color is very light/white
+    const h1 = rgbToValues(h1Color);
+    if (h1) {
+      expect(h1[0]).toBeGreaterThan(240); // Should be close to white
+      expect(h1[1]).toBeGreaterThan(240);
+      expect(h1[2]).toBeGreaterThan(240);
+    }
+    
+    // Test toggle back to light mode to ensure the functionality works both ways
+    await darkModeButton.click();
+    await page.waitForTimeout(1000);
+    
+    // Take another screenshot to confirm light mode
+    await page.screenshot({ 
+      path: 'src/test/playwright/images/iframe-light-mode-restored.png', 
+      fullPage: true 
+    });
+    
+    // Validate light mode is restored (body should have light background)
+    const lightBodyBgColor = await iframeContent.evaluate(() => {
+      const body = document.body;
+      return window.getComputedStyle(body).backgroundColor;
+    });
+    
+    console.log('Light mode body background:', lightBodyBgColor);
+    
+    // In light mode, background should be white or very light
+    const lightBodyBg = rgbToValues(lightBodyBgColor);
+    if (lightBodyBg) {
+      expect(lightBodyBg[0]).toBeGreaterThan(200); // Should be light
+      expect(lightBodyBg[1]).toBeGreaterThan(200);
+      expect(lightBodyBg[2]).toBeGreaterThan(200);
+    }
+    
+    console.log('✅ Dark mode visual validation completed successfully');
+  });
+  
+  test('confirms dark mode toggle affects multiple content types', async ({ page }) => {
+    // This test focuses on the visual differences across different content types
+    await page.goto('/');
+    await page.waitForSelector('app-root');
+    
+    // Enable mock mode
+    await page.evaluate(() => {
+      localStorage.setItem('mockMode', 'true');
+    });
+    
+    await page.reload();
+    await page.waitForSelector('bookmark-list', { timeout: 15000 });
+    
+    // Navigate to reader with test content
+    await page.goto(`/#/reader/999`);
+    await page.waitForSelector('bookmark-reader', { timeout: 10000 });
+    await page.waitForSelector('secure-iframe', { timeout: 10000 });
+    await page.waitForTimeout(2000);
+    
+    // Test on mobile viewport to ensure dark mode works on mobile browsers
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.waitForTimeout(500);
+    
+    // Activate dark mode
+    const darkModeButton = page.locator('md-icon-button[title*="Mode"]').first();
+    await darkModeButton.click();
+    await page.waitForTimeout(1000);
+    
+    // Take mobile dark mode screenshot
+    await page.screenshot({ 
+      path: 'src/test/playwright/images/iframe-dark-mode-mobile.png', 
+      fullPage: true 
+    });
+    
+    // Test on tablet size
+    await page.setViewportSize({ width: 768, height: 1024 });
+    await page.waitForTimeout(500);
+    
+    await page.screenshot({ 
+      path: 'src/test/playwright/images/iframe-dark-mode-tablet.png', 
+      fullPage: true 
+    });
+    
+    // Get iframe content for detailed validation
+    const iframe = page.locator('secure-iframe iframe').first();
+    const iframeHandle = await iframe.elementHandle();
+    if (!iframeHandle) {
+      throw new Error('Could not get iframe element handle');
+    }
+    
+    const iframeContent = await iframeHandle.contentFrame();
+    if (!iframeContent) {
+      throw new Error('Could not access iframe content');
+    }
+    
+    // Validate that dark mode CSS is actually injected into the iframe
+    const hasDarkModeStyles = await iframeContent.evaluate(() => {
+      // Look for the injected dark mode style element
+      const styles = Array.from(document.head.querySelectorAll('style'));
+      return styles.some(style => 
+        style.textContent && 
+        style.textContent.includes('background: #121212') &&
+        style.textContent.includes('color: #e0e0e0') &&
+        style.textContent.includes('Dark mode styles for readability content')
+      );
+    });
+    
+    expect(hasDarkModeStyles).toBe(true);
+    
+    // Validate table styling in dark mode
+    const tableCellBg = await iframeContent.evaluate(() => {
+      const td = document.querySelector('td');
+      if (!td) return 'not-found';
+      return window.getComputedStyle(td).backgroundColor;
+    });
+    
+    console.log('Table cell background in dark mode:', tableCellBg);
+    
+    // Validate blockquote border color (should be purple-ish)
+    const blockquoteBorder = await iframeContent.evaluate(() => {
+      const blockquote = document.querySelector('blockquote');
+      if (!blockquote) return 'not-found';
+      return window.getComputedStyle(blockquote).borderLeftColor;
+    });
+    
+    console.log('Blockquote border color:', blockquoteBorder);
+    
+    console.log('✅ Multi-content-type dark mode validation completed');
+  });
+});

--- a/src/test/unit/bookmark-reader-dark-mode.test.ts
+++ b/src/test/unit/bookmark-reader-dark-mode.test.ts
@@ -413,4 +413,57 @@ describe('BookmarkReader Dark Mode', () => {
       expect(ThemeService.removeThemeChangeListener).toHaveBeenCalled();
     });
   });
+
+  describe('iframe dark mode integration', () => {
+    beforeEach(async () => {
+      element.bookmarkId = 1;
+      await element.updateComplete;
+      // Wait for loadBookmark to complete
+      await new Promise(resolve => setTimeout(resolve, 0));
+      await element.updateComplete;
+    });
+
+    it('should pass correct dark mode state to secure iframe when dark override is set', async () => {
+      element['darkModeOverride'] = 'dark';
+      element['systemTheme'] = 'light';
+      await element.updateComplete;
+
+      const iframe = element.shadowRoot?.querySelector('secure-iframe') as any;
+      expect(iframe?.isDarkMode).toBe(true);
+    });
+
+    it('should pass correct dark mode state to secure iframe when light override is set', async () => {
+      element['darkModeOverride'] = 'light';
+      element['systemTheme'] = 'dark';
+      await element.updateComplete;
+
+      const iframe = element.shadowRoot?.querySelector('secure-iframe') as any;
+      expect(iframe?.isDarkMode).toBe(false);
+    });
+
+    it('should pass correct dark mode state to secure iframe when no override (follow system)', async () => {
+      element['darkModeOverride'] = null;
+      element['systemTheme'] = 'dark';
+      await element.updateComplete;
+
+      const iframe = element.shadowRoot?.querySelector('secure-iframe') as any;
+      expect(iframe?.isDarkMode).toBe(true);
+    });
+
+    it('should update iframe dark mode state when override changes', async () => {
+      // Start with no override and light system theme
+      element['darkModeOverride'] = null;
+      element['systemTheme'] = 'light';
+      await element.updateComplete;
+
+      const iframe = element.shadowRoot?.querySelector('secure-iframe') as any;
+      expect(iframe?.isDarkMode).toBe(false);
+
+      // Toggle to dark override
+      element['handleDarkModeToggle']();
+      await element.updateComplete;
+
+      expect(iframe?.isDarkMode).toBe(true);
+    });
+  });
 });

--- a/src/test/unit/security-service.test.ts
+++ b/src/test/unit/security-service.test.ts
@@ -212,4 +212,74 @@ describe('SecurityService', () => {
     });
   });
 
+  describe('Dark Mode Support', () => {
+    it('should not inject dark mode CSS when isDarkMode is false', async () => {
+      const inputHtml = `
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <title>Test Page</title>
+        </head>
+        <body>
+          <h1>Test Content</h1>
+          <p>Regular content</p>
+        </body>
+        </html>
+      `;
+
+      const result = await SecurityService.prepareSingleFileContent(inputHtml, false);
+      
+      expect(result).not.toContain('background: #121212');
+      expect(result).not.toContain('color: #e0e0e0');
+      expect(result).not.toContain('Dark mode styles for readability content');
+    });
+
+    it('should inject dark mode CSS when isDarkMode is true', async () => {
+      const inputHtml = `
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <title>Test Page</title>
+        </head>
+        <body>
+          <h1>Test Content</h1>
+          <p>Regular content</p>
+        </body>
+        </html>
+      `;
+
+      const result = await SecurityService.prepareSingleFileContent(inputHtml, true);
+      
+      expect(result).toContain('background: #121212 !important');
+      expect(result).toContain('color: #e0e0e0 !important');
+      expect(result).toContain('Dark mode styles for readability content');
+      expect(result).toContain('color: #bb86fc !important'); // Links
+      expect(result).toContain('background: #1e1e1e !important'); // Blockquotes/code
+    });
+
+    it('should inject dark mode CSS in correct order (before progress tracking)', async () => {
+      const inputHtml = `
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <title>Test Page</title>
+        </head>
+        <body>
+          <h1>Test Content</h1>
+        </body>
+        </html>
+      `;
+
+      const result = await SecurityService.prepareSingleFileContent(inputHtml, true);
+      
+      // Dark mode CSS should come before progress tracking script in the output
+      const darkModeIndex = result.indexOf('Dark mode styles for readability content');
+      const progressTrackerIndex = result.indexOf('progressTracker');
+      
+      expect(darkModeIndex).toBeGreaterThan(0);
+      expect(progressTrackerIndex).toBeGreaterThan(0);
+      expect(darkModeIndex).toBeLessThan(progressTrackerIndex);
+    });
+  });
+
 });


### PR DESCRIPTION
Found and fixed missing dark mode functionality in readability view:

- Added isDarkMode property to secure-iframe component
- Enhanced SecurityService to inject dark mode CSS into iframe content
- Updated bookmark-reader to pass dark mode state to iframe
- Added comprehensive dark mode styles with Material Design colors
- Included extensive test coverage for iframe dark mode integration

The dark mode button in readability view now properly applies dark theme styles inside the sandboxed iframe content, making it work correctly on mobile browsers.

Fixes #82

Generated with [Claude Code](https://claude.ai/code)