### PR TITLE
feat: add comprehensive version display system for PWA update verification

### DIFF
--- a/src/services/version-service.ts
+++ b/src/services/version-service.ts
@@ -1,0 +1,57 @@
+import type { VersionInfo } from '../types/version';
+
+/**
+ * Service for accessing application and service worker version information
+ */
+export class VersionService {
+  /**
+   * Get the main application version (from the build process)
+   */
+  static getAppVersion(): VersionInfo {
+    return __APP_VERSION__;
+  }
+
+  /**
+   * Get the service worker version by messaging it
+   */
+  static async getServiceWorkerVersion(): Promise<VersionInfo | null> {
+    if (!('serviceWorker' in navigator) || !navigator.serviceWorker.controller) {
+      return null;
+    }
+
+    return new Promise((resolve) => {
+      const channel = new MessageChannel();
+
+      channel.port1.onmessage = (event) => {
+        if (event.data.type === 'VERSION_INFO') {
+          resolve(event.data.version);
+        }
+      };
+
+      // Request version from service worker
+      const controller = navigator.serviceWorker.controller;
+      if (controller) {
+        controller.postMessage({
+          type: 'REQUEST_VERSION'
+        }, [channel.port2]);
+      } else {
+        resolve(null);
+      }
+
+      // Timeout after 2 seconds
+      setTimeout(() => resolve(null), 2000);
+    });
+  }
+
+  /**
+   * Check if main app and service worker versions differ
+   */
+  static async areVersionsDifferent(): Promise<boolean> {
+    const appVersion = this.getAppVersion();
+    const swVersion = await this.getServiceWorkerVersion();
+
+    if (!swVersion) return false;
+
+    return appVersion.buildTimestamp !== swVersion.buildTimestamp;
+  }
+}

--- a/src/types/sync-messages.ts
+++ b/src/types/sync-messages.ts
@@ -4,7 +4,7 @@
 
 import type { SyncPhase } from './index.js';
 
-export type SyncMessageType = 
+export type SyncMessageType =
   | 'REQUEST_SYNC'
   | 'CANCEL_SYNC'
   | 'SYNC_STATUS'
@@ -13,6 +13,8 @@ export type SyncMessageType =
   | 'SYNC_ERROR'
   | 'REGISTER_PERIODIC_SYNC'
   | 'CHECK_SYNC_PERMISSION'
+  | 'REQUEST_VERSION'
+  | 'VERSION_INFO'
   | 'SW_LOG';
 
 export interface SyncRequestMessage {
@@ -75,7 +77,16 @@ export interface ServiceWorkerLogMessage {
   error?: string;
 }
 
-export type SyncMessage = 
+export interface RequestVersionMessage {
+  type: 'REQUEST_VERSION';
+}
+
+export interface VersionInfoMessage {
+  type: 'VERSION_INFO';
+  version: import('./version').VersionInfo;
+}
+
+export type SyncMessage =
   | SyncRequestMessage
   | CancelSyncMessage
   | SyncStatusMessage
@@ -84,6 +95,8 @@ export type SyncMessage =
   | SyncErrorMessage
   | RegisterPeriodicSyncMessage
   | CheckSyncPermissionMessage
+  | RequestVersionMessage
+  | VersionInfoMessage
   | ServiceWorkerLogMessage;
 
 /**

--- a/src/types/version.ts
+++ b/src/types/version.ts
@@ -1,0 +1,10 @@
+export interface VersionInfo {
+  buildTimestamp: string;
+  githubRunId: string | null;
+  shortVersion: string;
+}
+
+// Global type declaration for Vite-injected version
+declare global {
+  const __APP_VERSION__: VersionInfo;
+}

--- a/src/worker/sw.ts
+++ b/src/worker/sw.ts
@@ -354,6 +354,18 @@ async function performSync(fullSync = false): Promise<void> {
  */
 self.addEventListener('message', async (event) => {
   const message = event.data as SyncMessage;
+
+  // Handle version requests
+  if (message.type === 'REQUEST_VERSION') {
+    const port = event.ports[0];
+    if (port) {
+      port.postMessage({
+        type: 'VERSION_INFO',
+        version: __APP_VERSION__
+      });
+    }
+    return;
+  }
   
   switch (message.type) {
     case 'REQUEST_SYNC':

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,15 +4,29 @@ import { VitePWA } from 'vite-plugin-pwa'
 export default defineConfig(({ command }) => {
   // Determine base path based on environment
   // For GitHub Pages, use the repository name as base path
-  const isGitHubPages = process.env.GITHUB_PAGES === 'true' || 
+  const isGitHubPages = process.env.GITHUB_PAGES === 'true' ||
                         process.env.GITHUB_ACTIONS === 'true' ||
                         process.env.CI === 'true'
-  
+
   const base = isGitHubPages ? '/pocket-ding/' : '/'
+
+  // Generate version information
+  const buildTimestamp = new Date().toISOString()
+  const githubRunId = process.env.GITHUB_RUN_ID || null
+  const versionInfo = {
+    buildTimestamp,
+    githubRunId,
+    // Create a short version string for display
+    shortVersion: buildTimestamp.replace(/[T:]/g, '-').substring(0, 16) + (githubRunId ? `-${githubRunId}` : '')
+  }
 
   return {
     base,
     root: '.',
+    define: {
+      // Inject version info into the build
+      __APP_VERSION__: JSON.stringify(versionInfo),
+    },
     plugins: [
       VitePWA({
         registerType: 'autoUpdate',


### PR DESCRIPTION
Implement build-time version generation and runtime version comparison to help
verify that immediate PWA updates are working correctly. This addresses the
need to confirm when app and service worker versions are synchronized.

Features:
- Build-time version injection with timestamp and GitHub Actions run ID
- VersionService for accessing app and service worker version info
- Settings panel display showing both versions with mismatch detection
- Service worker message handling for version requests
- Clear visual indicators when versions differ

Technical changes:
- Add __APP_VERSION__ global via Vite define configuration
- Create VersionService for version management and comparison
- Extend sync message types to support version requests
- Add version info section to settings panel with styling
- Implement service worker version messaging protocol

This enables users to verify that immediate PWA updates are functioning
properly and helps debug update synchronization issues.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
