### PR TITLE
fix: resolve service worker script evaluation error and restore caching strategies

### DIFF
--- a/src/worker/README.md
+++ b/src/worker/README.md
@@ -1,0 +1,26 @@
+# Service Worker Development Guidelines
+
+## ⚠️ CRITICAL: Context Boundaries
+
+Service workers run in a different context than browser code. Follow these rules:
+
+### ✅ SAFE to import in service workers:
+- `../types/*` - Type definitions only
+- `./sw-*` - Service worker specific utilities
+- `workbox-*` - Workbox libraries
+- Pure utility functions with no side effects
+
+### ❌ DANGEROUS to import in service workers:
+- `../services/*` - Browser services (may use DOM APIs)
+- `../components/*` - UI components
+- `../controllers/*` - Browser controllers
+- Anything that uses `window`, `document`, `localStorage`
+
+### 🔍 Before adding ANY import:
+1. Check if the imported code uses browser APIs
+2. Test the service worker in production build mode
+3. Verify version display works in settings
+
+### Current Technical Debt:
+- `DatabaseService` import should be refactored to use context-specific implementations
+- Consider creating `@shared`, `@browser`, `@worker` directories in future

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,36 +35,9 @@ export default defineConfig(({ command }) => {
         filename: 'sw.ts',
         injectManifest: {
           globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
-          // Service worker content changes on each build due to __APP_VERSION__
           injectionPoint: 'self.__WB_MANIFEST',
-        },
-        workbox: {
-          skipWaiting: true,
-          clientsClaim: true,
-          // More aggressive cache invalidation
-          cleanupOutdatedCaches: true,
-          runtimeCaching: [
-            {
-              urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,
-              handler: 'CacheFirst',
-              options: {
-                cacheName: 'google-fonts-cache',
-                expiration: {
-                  maxEntries: 10,
-                  maxAgeSeconds: 60 * 60 * 24 * 365 // 1 year
-                }
-              }
-            },
-            {
-              // Force network-first for main app JavaScript files
-              urlPattern: /\/main-[a-zA-Z0-9_-]+\.js$/,
-              handler: 'NetworkFirst',
-              options: {
-                cacheName: 'app-js-cache',
-                networkTimeoutSeconds: 2
-              }
-            }
-          ]
+          // Configure Rollup options for service worker build
+          rollupFormat: 'iife',
         },
         manifest: {
           name: 'Pocket Ding',


### PR DESCRIPTION
- Configure VitePWA with rollupFormat: 'iife' to prevent browser API inclusion in service worker
- Restore missing caching strategies from removed workbox config:
  * Google Fonts cache-first strategy with 1-year expiration
  * App JavaScript network-first strategy to ensure updates
- Remove duplicate activate event listener and consolidate functionality
- Add service worker development guidelines documentation

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
