### PR TITLE
perf: add caching for Playwright browsers in CI

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -43,7 +43,19 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
+    - name: Get Playwright version
+      id: playwright-version
+      run: echo "version=$(npm list @playwright/test --depth=0 --json | jq -r '.dependencies["@playwright/test"].version')" >> $GITHUB_OUTPUT
+
+    - name: Cache Playwright browsers
+      uses: actions/cache@v4
+      id: playwright-cache
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
     - name: Install Playwright browsers
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
       run: npx playwright install --with-deps chromium
 
     - name: Build project for E2E tests


### PR DESCRIPTION
## Summary
- Add browser caching to the E2E tests job in the PR checks workflow
- Cache is keyed by OS and Playwright version for automatic invalidation on upgrades
- Browsers are only downloaded on cache miss, significantly speeding up CI runs

## Benefits
- **Faster CI**: Browser restore from cache takes seconds vs. 30+ seconds to download
- **Reduced bandwidth**: Avoids redundant browser downloads on every run
- **Auto-invalidation**: Cache refreshes when Playwright version changes

## Test plan
- [x] Workflow syntax verified
- CI will validate on first run

🤖 Generated with [Claude Code](https://claude.com/claude-code)